### PR TITLE
Adding information about the Rust FFI language bindings

### DIFF
--- a/Developer-guide/Language Bindings.md
+++ b/Developer-guide/Language Bindings.md
@@ -30,3 +30,10 @@ Ruby
 
 -   [libgfapi-ruby](https://github.com/spajus/libgfapi-ruby) - Libgfapi
     bindings for Ruby using FFI
+
+Rust
+----
+
+-   [gfapi-sys](https://github.com/cholcombe973/Gfapi-sys) - Libgfapi
+    bindings for Rust using FFI
+

--- a/Features/libgfapi.md
+++ b/Features/libgfapi.md
@@ -369,6 +369,7 @@ libgfapi bindings are available for below languages:
     - Java
     - python [2]
     - Ruby
+    - Rust
 
 For more details on these bindings,please refer :
 


### PR DESCRIPTION
I created FFI bindings for libgfapi this morning in Rust.  I'm adding a link to the official docs.  