### PR TITLE
Update the pages configuration for MkDocs 0.13

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,156 +3,148 @@ site_url: http://www.gluster.org
 site_description: Project documentation for Gluster Filesystem
 
 repo_url: https://github.com/humblec/glusterdocs/
+docs_dir: .
 
 pages:
-- ['index.md', 'Home']
-
-# **************************
-# **DROP DOWN MENU OPTIONS** 
-# **************************
-
-# Quickstart Guide:
-- ['Quick-Start-Guide/Quickstart.md', 'Quickstart Guide', 'Quick start']
-- ['Quick-Start-Guide/Terminologies.md', 'Quickstart Guide', 'Terminologies']
-- ['Quick-Start-Guide/Architecture.md', 'Quickstart Guide', 'Architecture']
-
-# Installation Guide:
-- ['Install-Guide/Overview.md', 'Install Guide', 'Overview']
-- ['Install-Guide/Common_criteria.md', 'Install Guide', 'Common Criteria']
-- ['Install-Guide/Quick_start.md', 'Install Guide', 'Quick start to Install']
-- ['Install-Guide/Setup_virt.md', 'Install Guide', 'Setting up in virtual machines']
-- ['Install-Guide/Setup_Bare_metal.md', 'Install Guide', 'Setting up on physical servers']
-- ['Install-Guide/Setup_aws.md', 'Install Guide', 'Deploying in AWS']
-- ['Install-Guide/Install.md', 'Install Guide', 'Install']
-- ['Install-Guide/Configure.md', 'Install Guide', 'Configure']
-
-# Administrator Guide:
-- ['Administrator Guide/README.md', 'Administrator Guide', 'Index']
-- ['Administrator Guide/GlusterFS Introduction.md', 'Administrator Guide', 'GlusterFS Introduction']
-- ['Administrator Guide/glossary.md', 'Administrator Guide', 'Glossary']
-- ['Administrator Guide/Did You Know.md', 'Administrator Guide', 'Did You Know']
-- ['Administrator Guide/Storage Pools.md', 'Administrator Guide', 'Storage Pools']
-- ['Administrator Guide/Compiling RPMS.md', 'Administrator Guide', 'Compiling RPMS']
-- ['Administrator Guide/Start Stop Daemon.md', 'Administrator Guide', 'Managing the Gluster Service']
-- ['Administrator Guide/Console.md', 'Administrator Guide', 'Gluster Console Guide']
-- ['Administrator Guide/Access Control Lists.md', 'Administrator Guide', 'Access Control Lists']
-- ['Administrator Guide/Setting Up Clients.md', 'Administrator Guide', 'Setting Up Clients']
-- ['Administrator Guide/Setting Up Volumes.md', 'Administrator Guide', 'Setting Up Volumes']
-- ['Administrator Guide/Managing Volumes.md', 'Administrator Guide', 'Managing Volumes']
-- ['Administrator Guide/Building QEMU With gfapi For Debian Based Systems.md', 'Administrator Guide', 'Building QEMU with gfapi For Debian Based Systems']
-- ['Administrator Guide/GlusterFS Filter.md', 'Administrator Guide', 'GlusterFS Filter']
-- ['Administrator Guide/Resolving Peer Rejected.md', 'Administrator Guide', 'Resolving Peer Rejected State']
-- ['Administrator Guide/Logging.md', 'Administrator Guide', 'Logging']
-- ['Administrator Guide/Brick Naming Conventions.md', 'Administrator Guide', 'Brick Naming Conventions']
-- ['Administrator Guide/Geo Replication.md', 'Administrator Guide', 'Geo Replication']
-- ['Administrator Guide/Distributed Geo Replication.md', 'Administrator Guide', 'Distributed Geo Replication']
-- ['Administrator Guide/Directory Quota.md', 'Administrator Guide', 'Directory Quota']
-- ['Administrator Guide/Managing Snapshots.md', 'Administrator Guide', 'Managing Snapshots']
-- ['Administrator Guide/Monitoring Workload.md', 'Administrator Guide', 'Monitoring Workload']
-- ['Administrator Guide/Object Storage.md', 'Administrator Guide', 'Object Storage']
-- ['Administrator Guide/GlusterFS Cinder.md', 'Administrator Guide', 'GlusterFS Cinder']
-- ['Administrator Guide/GlusterFS Keystone Quickstart.md', 'Administrator Guide', 'GlusterFS Keystone Quickstart']
-- ['Administrator Guide/Hadoop.md', 'Administrator Guide', 'Hadoop']
-- ['Administrator Guide/Gluster On ZFS.md', 'Administrator Guide', 'Gluster On ZFS']
-- ['Administrator Guide/SSL.md', 'Administrator Guide', 'SSL']
-- ['Administrator Guide/Puppet.md', 'Administrator Guide', 'Puppet Gluster']
-- ['Administrator Guide/RDMA Transport.md', 'Administrator Guide', 'RDMA Transport']
-- ['Administrator Guide/GlusterFS iSCSI.md', 'Administrator Guide', 'GlusterFS iSCSI']
-- ['Administrator Guide/Linux Kernel Tuning.md', 'Administrator Guide', 'Linux Kernel Tuning']
-- ['Administrator Guide/Network Configurations Techniques.md', 'Administrator Guide', 'Network Configurations Techniques']
-- ['Administrator Guide/Performance Testing.md', 'Administrator Guide', 'Performance Testing']
-
-# Developers Guide:
-- ['Developer-guide/Developers Index.md', 'Developers Guide', 'Developers Home']
-- ['Developer-guide/Simplified Development Workflow.md', 'Developers Guide', 'Simplified Development Workflow']
-- ['Developer-guide/Development Workflow.md', 'Developers Guide', 'Development Workflow']
-- ['Developer-guide/coding-standard.md', 'Developers Guide', 'Coding Standards']
-- ['Developer-guide/Compiling RPMS.md', 'Developers Guide', 'Compiling RPMS']
-- ['Developer-guide/Building GlusterFS.md', 'Developers Guide', 'Building GlusterFS']
-- ['Developer-guide/Projects.md', 'Developers Guide', 'Projects']
-- ['Developer-guide/Language Bindings.md', 'Developers Guide', 'Language Bindings']
-- ['Developer-guide/Easy Fix Bugs.md', 'Developers Guide', 'Easy Fix Bugs']
-- ['Developer-guide/Fixing issues reported by tools for static code analysis.md', 'Developers Guide', 'Fixing issues for static code analysis']
-- ['Developer-guide/Backport Wishlist.md', 'Developers Guide', 'Backport Wishlist']
-- ['Developer-guide/Backport Guidelines.md', 'Developers Guide', 'Backport Guidelines']
-- ['Developer-guide/adding-fops.md', 'Developers Guide', 'Adding File Operations']
-- ['Developer-guide/afr.md', 'Developers Guide', 'Automatic File Replication']
-- ['Developer-guide/afr-locks-evolution.md', 'Developers Guide', 'History of Locking in AFR']
-- ['Developer-guide/afr-self-heal-daemon.md', 'Developers Guide', 'Seal heal Daemon']
-- ['Developer-guide/datastructure-inode.md', 'Developers Guide', 'inode datastructure']
-- ['Developer-guide/datastructure-iobuf.md', 'Developers Guide', 'iobuf datastructure']
-- ['Developer-guide/datastructure-mem-pool.md', 'Developers Guide', 'mem-pool datastructure']
-- ['Developer-guide/gfapi-symbol-versions.md', 'Developers Guide', 'gfapi Symbol Versions']
-- ['Developer-guide/daemon-management-framework.md', 'Developers Guide', 'Daemon Management Framework']
-- ['Developer-guide/bd-xlator.md', 'Developers Guide', 'Block Device Translator']
-- ['Developer-guide/write-behind.md', 'Developers Guide', 'Write Behind Translator']
-- ['Developer-guide/translator-development.md', 'Developers Guide', 'Translator Development']
-- ['Developer-guide/posix.md', 'Developers Guide', 'Storage/posix Translator']
-- ['Developer-guide/network_compression.md', 'Developers Guide', 'Compression Translator']
-- ['Developer-guide/unittest.md', 'Developers Guide', 'Unit Tests in GlusterFS']
-- ['Developer-guide/Using Gluster Test Framework.md', 'Developers Guide', 'Using Gluster Test Framework']
-- ['Developer-guide/Jenkins Infrastructure.md', 'Developers Guide', 'Jenkins Infrastructure']
-- ['Developer-guide/Jenkins Manual Setup.md', 'Developers Guide', 'Jenkins Manual Setup']
-- ['Developer-guide/Bug Reporting Guidelines.md', 'Developers Guide', 'Bug Reporting Guidelines']
-- ['Developer-guide/Bug Triage.md', 'Developers Guide', 'Bug Triage Guidelines']
-- ['Developer-guide/Bug report Life Cycle.md', 'Developers Guide', 'Bug Report Life Cycle']
-- ['Developer-guide/Guidelines For Maintainers.md', 'Developers Guide', 'Guidelines for Maintainers']
-- ['Developer-guide/versioning.md', 'Developers Guide', 'Versioning']
-- ['Developer-guide/GlusterFS Release process.md', 'Developers Guide', 'GlusterFS Release Process']
-- ['Developer-guide/Bug reporting template.md', 'Developers Guide', 'Bug Reporting Template']
-
-# Upgrade Guide:
-- ['Upgrade-Guide/README.md', 'Upgrade-Guide', 'Upgrade-Guide Index']
-- ['Upgrade-Guide/upgrade_to_3.5.md', 'Upgrade-Guide', 'Upgrade to 3.5']
-- ['Upgrade-Guide/upgrade_to_3.6.md', 'Upgrade-Guide', 'Upgrade to 3.6']
-- ['Upgrade-Guide/Upgrade to 3.7.md', 'Upgrade-Guide', 'Upgrade to 3.7']
-
-# Features:
-- ['Features/README.md', 'Features', 'Features List']
-- ['Features/afr-arbiter-volumes.md', 'Features', 'AFR Arbiter Volumes']
-- ['Features/bitrot-docs.md', 'Features', 'bitrot docs']
-- ['Features/memory-usage.md', 'Features', 'bitrot memory usage']
-- ['Features/object-versioning.md', 'Features', 'Object Versioning']
-- ['Features/shard.md', 'Features', 'shard']
-- ['Features/upcall.md', 'Features', 'upcall']
-- ['Features/quota-object-count.md', 'Features', 'quota object count']
-- ['Features/glusterfs_nfs-ganesha_integration.md', 'Features', 'nfs-ganesha integration']
-- ['Features/tier.md', 'Features', 'tiering']
-- ['Features/trash_xlator.md', 'Features', 'trash_xlator']
-- ['Features/afr-statistics.md', 'Features', 'AFR Statistics']
-- ['Features/afr-v1.md', 'Features', 'AFR ver1']
-- ['Features/brick-failure-detection.md', 'Features', 'Brick Failure Detection']
-- ['Features/file-snapshot.md', 'Features', 'File Snapshot']
-- ['Features/gfid-access.md', 'Features', 'gfid Access']
-- ['Features/quota-scalability.md', 'Features', 'Quota Scalability']
-- ['Features/readdir-ahead.md', 'Features', 'readdir ahead']
-- ['Features/zerofill.md', 'Features', 'zerofill']
-- ['Features/dht.md', 'Features', 'Distributed Hash Tables']
-- ['Features/heal-info-and-split-brain-resolution.md', 'Features', 'heal info and split brain resolution']
-- ['Features/libgfapi.md', 'Features', 'libgfapi']
-- ['Features/mount_gluster_volume_using_pnfs.md', 'Features', 'Mount Gluster Volume using pNFS']
-- ['Features/nufa.md', 'Features', 'Non Uniform File Access']
-- ['Features/ovirt-integration.md', 'Features', 'ovirt integration']
-- ['Features/qemu-integration.md', 'Features', 'qemu integration']
-- ['Features/rdmacm.md', 'Features', 'RDMA Connection Manager']
-- ['Features/rebalance.md', 'Features', 'Rebalance']
-- ['Features/server-quorum.md', 'Features', 'Server Quorum']
-- ['Features/worm.md', 'Features', 'Write Once Read Many']
-- ['Features/distributed-geo-rep.md', 'Features', 'Distributed Geo Replication']
-- ['Features/libgfchangelog.md', 'Features', 'libgf Changelog']
-- ['Features/meta.md', 'Features', 'meta xlator']
-
-#GlusterFS Tools
-- ['GlusterFS Tools/README.md', 'GlusterFS Tools', 'GlusterFS Tools List']
-- ['GlusterFS Tools/glusterfind.md', 'GlusterFS Tools', 'glusterfind']
-- ['GlusterFS Tools/gfind_missing_files.md', 'GlusterFS Tools', 'gfind missing files']
-
-# Troubleshooting Guide
-- ['Troubleshooting/README.md', 'Troubleshooting Guide', 'Index']
-- ['Troubleshooting/Common Scenarios.md', 'Troubleshooting Guide', 'Common Scenarios']
-- ['Troubleshooting/troubleshootingFAQ.md', 'Troubleshooting Guide', 'FAQs']
-- ['Troubleshooting/gfid-to-path.md', 'Troubleshooting Guide', 'gfid to path']
-- ['Troubleshooting/split-brain.md', 'Troubleshooting Guide', 'Split Brain']
-- ['Troubleshooting/statedump.md', 'Troubleshooting Guide', 'Statedump']
+- Home: index.md
+- Quickstart Guide:
+  - Quick start: Quick-Start-Guide/Quickstart.md
+  - Terminologies: Quick-Start-Guide/Terminologies.md
+  - Architecture: Quick-Start-Guide/Architecture.md
+- Install Guide:
+  - Overview: Install-Guide/Overview.md
+  - Common Criteria: Install-Guide/Common_criteria.md
+  - Quick start to Install: Install-Guide/Quick_start.md
+  - Setting up in virtual machines: Install-Guide/Setup_virt.md
+  - Setting up on physical servers: Install-Guide/Setup_Bare_metal.md
+  - Deploying in AWS: Install-Guide/Setup_aws.md
+  - Install: Install-Guide/Install.md
+  - Configure: Install-Guide/Configure.md
+- Administrator Guide:
+  - Index: Administrator Guide/README.md
+  - GlusterFS Introduction: Administrator Guide/GlusterFS Introduction.md
+  - Glossary: Administrator Guide/glossary.md
+  - Did You Know: Administrator Guide/Did You Know.md
+  - Storage Pools: Administrator Guide/Storage Pools.md
+  - Compiling RPMS: Administrator Guide/Compiling RPMS.md
+  - Managing the Gluster Service: Administrator Guide/Start Stop Daemon.md
+  - Gluster Console Guide: Administrator Guide/Console.md
+  - Access Control Lists: Administrator Guide/Access Control Lists.md
+  - Setting Up Clients: Administrator Guide/Setting Up Clients.md
+  - Setting Up Volumes: Administrator Guide/Setting Up Volumes.md
+  - Managing Volumes: Administrator Guide/Managing Volumes.md
+  - Building QEMU with gfapi For Debian Based Systems: Administrator Guide/Building
+      QEMU With gfapi For Debian Based Systems.md
+  - GlusterFS Filter: Administrator Guide/GlusterFS Filter.md
+  - Resolving Peer Rejected State: Administrator Guide/Resolving Peer Rejected.md
+  - Logging: Administrator Guide/Logging.md
+  - Brick Naming Conventions: Administrator Guide/Brick Naming Conventions.md
+  - Geo Replication: Administrator Guide/Geo Replication.md
+  - Distributed Geo Replication: Administrator Guide/Distributed Geo Replication.md
+  - Directory Quota: Administrator Guide/Directory Quota.md
+  - Managing Snapshots: Administrator Guide/Managing Snapshots.md
+  - Monitoring Workload: Administrator Guide/Monitoring Workload.md
+  - Object Storage: Administrator Guide/Object Storage.md
+  - GlusterFS Cinder: Administrator Guide/GlusterFS Cinder.md
+  - GlusterFS Keystone Quickstart: Administrator Guide/GlusterFS Keystone Quickstart.md
+  - Hadoop: Administrator Guide/Hadoop.md
+  - Gluster On ZFS: Administrator Guide/Gluster On ZFS.md
+  - SSL: Administrator Guide/SSL.md
+  - Puppet Gluster: Administrator Guide/Puppet.md
+  - RDMA Transport: Administrator Guide/RDMA Transport.md
+  - GlusterFS iSCSI: Administrator Guide/GlusterFS iSCSI.md
+  - Linux Kernel Tuning: Administrator Guide/Linux Kernel Tuning.md
+  - Network Configurations Techniques: Administrator Guide/Network Configurations
+      Techniques.md
+  - Performance Testing: Administrator Guide/Performance Testing.md
+- Developers Guide:
+  - Developers Home: Developer-guide/Developers Index.md
+  - Simplified Development Workflow: Developer-guide/Simplified Development Workflow.md
+  - Development Workflow: Developer-guide/Development Workflow.md
+  - Coding Standards: Developer-guide/coding-standard.md
+  - Compiling RPMS: Developer-guide/Compiling RPMS.md
+  - Building GlusterFS: Developer-guide/Building GlusterFS.md
+  - Projects: Developer-guide/Projects.md
+  - Language Bindings: Developer-guide/Language Bindings.md
+  - Easy Fix Bugs: Developer-guide/Easy Fix Bugs.md
+  - Fixing issues for static code analysis: Developer-guide/Fixing issues reported
+      by tools for static code analysis.md
+  - Backport Wishlist: Developer-guide/Backport Wishlist.md
+  - Backport Guidelines: Developer-guide/Backport Guidelines.md
+  - Adding File Operations: Developer-guide/adding-fops.md
+  - Automatic File Replication: Developer-guide/afr.md
+  - History of Locking in AFR: Developer-guide/afr-locks-evolution.md
+  - Seal heal Daemon: Developer-guide/afr-self-heal-daemon.md
+  - inode datastructure: Developer-guide/datastructure-inode.md
+  - iobuf datastructure: Developer-guide/datastructure-iobuf.md
+  - mem-pool datastructure: Developer-guide/datastructure-mem-pool.md
+  - gfapi Symbol Versions: Developer-guide/gfapi-symbol-versions.md
+  - Daemon Management Framework: Developer-guide/daemon-management-framework.md
+  - Block Device Translator: Developer-guide/bd-xlator.md
+  - Write Behind Translator: Developer-guide/write-behind.md
+  - Translator Development: Developer-guide/translator-development.md
+  - Storage/posix Translator: Developer-guide/posix.md
+  - Compression Translator: Developer-guide/network_compression.md
+  - Unit Tests in GlusterFS: Developer-guide/unittest.md
+  - Using Gluster Test Framework: Developer-guide/Using Gluster Test Framework.md
+  - Jenkins Infrastructure: Developer-guide/Jenkins Infrastructure.md
+  - Jenkins Manual Setup: Developer-guide/Jenkins Manual Setup.md
+  - Bug Reporting Guidelines: Developer-guide/Bug Reporting Guidelines.md
+  - Bug Triage Guidelines: Developer-guide/Bug Triage.md
+  - Bug Report Life Cycle: Developer-guide/Bug report Life Cycle.md
+  - Guidelines for Maintainers: Developer-guide/Guidelines For Maintainers.md
+  - Versioning: Developer-guide/versioning.md
+  - GlusterFS Release Process: Developer-guide/GlusterFS Release process.md
+  - Bug Reporting Template: Developer-guide/Bug reporting template.md
+- Upgrade-Guide:
+  - Upgrade-Guide Index: Upgrade-Guide/README.md
+  - Upgrade to 3.5: Upgrade-Guide/upgrade_to_3.5.md
+  - Upgrade to 3.6: Upgrade-Guide/upgrade_to_3.6.md
+  - Upgrade to 3.7: Upgrade-Guide/Upgrade to 3.7.md
+- Features:
+  - Features List: Features/README.md
+  - AFR Arbiter Volumes: Features/afr-arbiter-volumes.md
+  - bitrot docs: Features/bitrot-docs.md
+  - bitrot memory usage: Features/memory-usage.md
+  - Object Versioning: Features/object-versioning.md
+  - shard: Features/shard.md
+  - upcall: Features/upcall.md
+  - quota object count: Features/quota-object-count.md
+  - nfs-ganesha integration: Features/glusterfs_nfs-ganesha_integration.md
+  - tiering: Features/tier.md
+  - trash_xlator: Features/trash_xlator.md
+  - AFR Statistics: Features/afr-statistics.md
+  - AFR ver1: Features/afr-v1.md
+  - Brick Failure Detection: Features/brick-failure-detection.md
+  - File Snapshot: Features/file-snapshot.md
+  - gfid Access: Features/gfid-access.md
+  - Quota Scalability: Features/quota-scalability.md
+  - readdir ahead: Features/readdir-ahead.md
+  - zerofill: Features/zerofill.md
+  - Distributed Hash Tables: Features/dht.md
+  - heal info and split brain resolution: Features/heal-info-and-split-brain-resolution.md
+  - libgfapi: Features/libgfapi.md
+  - Mount Gluster Volume using pNFS: Features/mount_gluster_volume_using_pnfs.md
+  - Non Uniform File Access: Features/nufa.md
+  - ovirt integration: Features/ovirt-integration.md
+  - qemu integration: Features/qemu-integration.md
+  - RDMA Connection Manager: Features/rdmacm.md
+  - Rebalance: Features/rebalance.md
+  - Server Quorum: Features/server-quorum.md
+  - Write Once Read Many: Features/worm.md
+  - Distributed Geo Replication: Features/distributed-geo-rep.md
+  - libgf Changelog: Features/libgfchangelog.md
+  - meta xlator: Features/meta.md
+- GlusterFS Tools:
+  - GlusterFS Tools List: GlusterFS Tools/README.md
+  - glusterfind: GlusterFS Tools/glusterfind.md
+  - gfind missing files: GlusterFS Tools/gfind_missing_files.md
+- Troubleshooting Guide:
+  - Index: Troubleshooting/README.md
+  - Common Scenarios: Troubleshooting/Common Scenarios.md
+  - FAQs: Troubleshooting/troubleshootingFAQ.md
+  - gfid to path: Troubleshooting/gfid-to-path.md
+  - Split Brain: Troubleshooting/split-brain.md
+  - Statedump: Troubleshooting/statedump.md
 
 theme: readthedocs


### PR DESCRIPTION
This change uses the new style of pages configuration that was added in
MkDocs 0.13.

This change also defines the docs_dir, ReadTheDocs doesn't need this but
if you wany to build the documentation locally you will.

This change was done with https://gist.github.com/d0ugal/53a1af8ec63c906cc203 and then manually removing the `{` and `}`.