### PR TITLE
release-process: correct the link to the packaging mailinglist

### DIFF
--- a/Developer-guide/GlusterFS Release process.md
+++ b/Developer-guide/GlusterFS Release process.md
@@ -16,7 +16,7 @@ Notify packagers
 
 Notify the packagers that we need packages created. Provide the link to the
 source tarball from the Jenkins release job to the [packagers
-mailinglist](mailto:packagers@gluster.org). A list of the people involved in
+mailinglist](mailto:packaging@gluster.org). A list of the people involved in
 the package maintenance for the different distributions is in the `MAINTAINERS`
 file in the sources.
 


### PR DESCRIPTION
The mailinglist for the packagers from different distributions is
packaging@gluster.org.

Signed-off-by: Niels de Vos <ndevos@redhat.com>