### PR TITLE
Re-adding workflow documents

### DIFF
--- a/Workflow-Guide/Bug-Reporting-Guidelines.md
+++ b/Workflow-Guide/Bug-Reporting-Guidelines.md
@@ -1,0 +1,128 @@
+Before filing a bug
+-------------------
+
+If you are finding any issues, these preliminary checks as useful:
+
+-   Is SELinux enabled? (you can use `getenforce` to check)
+-   Are iptables rules blocking any data traffic? (`iptables -L` can
+    help check)
+-   Are all the nodes reachable from each other? [ Network problem ]
+-   Please search Bugzilla to see if the bug has already been reported
+    -   Choose GlusterFS as the "product", and then type something
+        relevant in the "words" box. If you are seeing a crash or abort,
+        searching for part of the abort message might be effective. If
+        you are feeling adventurous you can select the "Advanced search"
+        tab; this gives a lot more control but isn't much better for
+        finding existing bugs.
+    -   If a bug has been already filed for a particular release and you
+        found the bug in another release,
+        -   please clone the existing bug for the release, you found the
+            issue.
+        -   If the existing bug is against mainline and you found the
+            issue for a release, then the cloned bug *depends on* should
+            be set to the BZ for mainline bug.
+
+Anyone can search in Bugzilla, you don't need an account. Searching
+requires some effort, but helps avoid duplicates, and you may find that
+your problem has already been solved.
+
+Reporting A Bug
+---------------
+
+-   You should have a Bugzilla account
+-   Here is the link to file a bug:
+    [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=GlusterFS)
+-   The template for filing a bug can be found [
+    *here*](./Bug reporting template.md)
+
+*Note: Please go through all below sections to understand what
+information we need to put in a bug. So it will help the developer to
+root cause and fix it*
+
+### Required Information
+
+You should gather the information below before creating the bug report.
+
+#### Package Information
+
+-   Location from which the packages are used
+-   Package Info - version of glusterfs package installed
+
+#### Cluster Information
+
+-   Number of nodes in the cluster
+-   Hostnames and IPs of the gluster Node [if it is not a security
+    issue]
+    -   Hostname / IP will help developers in understanding &
+        correlating with the logs
+-   Output of `gluster peer status`
+-   Node IP, from which the "x" operation is done
+    -   "x" here means any operation that causes the issue
+
+#### Volume Information
+
+-   Number of volumes
+-   Volume Names
+-   Volume on which the particular issue is seen [ if applicable ]
+-   Type of volumes
+-   Volume options if available
+-   Output of `gluster volume info`
+-   Output of `gluster volume status`
+-   Get the statedump of the volume with the problem
+
+`   $ gluster volume statedump `<vol-name>
+
+This dumps statedump per brick process in `/var/run/gluster`
+
+*NOTE: Collect statedumps from one gluster Node in a directory.*
+
+Repeat it in all Nodes containing the bricks of the volume. All the so
+collected directories could be archived,compressed and attached to bug
+
+#### Brick Information
+
+-   xfs options when brick partition was done
+    -   This could be obtained with this command :
+
+`   $ xfs_info /dev/mapper/vg1-brick`
+
+-   Extended attributes on the bricks
+    -   This could be obtained with this command:
+
+`   $ getfattr -d -m. -ehex /rhs/brick1/b1`
+
+#### Client Information
+
+-   OS Type ( Windows, RHEL )
+-   OS Version : In case of Linux distro get the following :
+
+`   $ uname -r`\
+`   $ cat /etc/issue`
+
+-   Fuse or NFS Mount point on the client with output of mount commands
+-   Output of `df -Th` command
+
+#### Tool Information
+
+-   If any tools are used for testing, provide the info/version about it
+-   if any IO is simulated using a script, provide the script
+
+#### Logs Information
+
+-   You can check logs for check for issues/warnings/errors.
+    -   Self-heal logs
+    -   Rebalance logs
+    -   Glusterd logs
+    -   Brick logs
+    -   NFS logs (if applicable)
+    -   Samba logs (if applicable)
+    -   Client mount log
+-   Add the entire logs as attachment, if its very large to paste as a
+    comment
+
+#### SOS report for CentOS/Fedora
+
+-   Get the sosreport from the involved gluster Node and Client [ in
+    case of CentOS /Fedora ]
+-   Add a meaningful name/IP to the sosreport, by renaming/adding
+    hostname/ip to the sosreport name

--- a/Workflow-Guide/Bug-Triage.md
+++ b/Workflow-Guide/Bug-Triage.md
@@ -1,0 +1,400 @@
+Bug Triage Guidelines
+=====================
+
+-   Triaging of bugs is an important task; when done correctly, it can
+    reduce the time between reporting a bug and the availability of a
+    fix enormously.
+
+-   Triager should focus on new bugs, and try to define the problem
+    easily understandable and as accurate as possible. The goal of the
+    triagers is to reduce the time that developers need to solve the bug
+    report.
+
+-   A triager is like an assistant that helps with the information
+    gathering and possibly the debugging of a new bug report. Because a
+    triager helps preparing a bug before a developer gets involved, it
+    can be a very nice role for new community members that are
+    interested in technical aspects of the software.
+
+-   Triagers will stumble upon many different kind of issues, ranging
+    from reports about spelling mistakes, or unclear log messages to
+    memory leaks causing crashes or performance issues in environments
+    with several hundred storage servers.
+
+Nobody expects that triagers can prepare all bug reports. Therefore most
+developers will be able to assist the triagers, answer questions and
+suggest approaches to debug and data to gather. Over time, triagers get
+more experienced and will rely less on developers.
+
+**Bug triage can be summarised as below points:**
+
+-   Is there enough information in the bug description?
+-   Is it a duplicate bug?
+-   Is it assigned to correct component of GlusterFS?
+-   Are the Bugzilla fields correct?
+-   Is the bug summary is correct?
+-   Assigning bugs or Adding people to the "CC" list
+-   Fix the Severity And Priority.
+-   Todo, If the bug present in multiple GlusterFS versions.
+-   Add appropriate Keywords to bug.
+
+The detailed discussion about the above points are below.
+
+Weekly meeting about Bug Triaging
+---------------------------------
+
+We try to meet every week in \#gluster-meeting on Freenode. The meeting
+date and time for the next meeting is normally updated in the
+[agenda](https://public.pad.fsfe.org/p/gluster-bug-triage).
+
+Getting Started: Find reports to triage
+---------------------------------------
+
+There are many different techniques and approaches to find reports to
+triage. One easy way is to use these pre-defined Bugzilla reports (a
+report is completely structured in the URL and can manually be
+modified):
+
+-   New **bugs** that do not have the 'Triaged' keyword [Bugzilla
+    link](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&f1=keywords&keywords=Triaged%2CFutureFeature&keywords_type=nowords&list_id=3014117&o1=nowords&product=GlusterFS&query_format=advanced&v1=Triaged)
+-   New **features** that do not have the 'Triaged' keyword (identified
+    by FutureFeature keyword, probably of interest only to project
+    leaders) [Bugzilla
+    link](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&f1=keywords&f2=keywords&list_id=3014699&o1=nowords&o2=allwords&product=GlusterFS&query_format=advanced&v1=Triaged&v2=FutureFeature)
+-   New glusterd bugs: [Bugzilla
+    link](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&product=GlusterFS&f1=keywords&o1=nowords&v1=Triaged&component=glusterd)
+-   New Replication(afr) bugs: [Bugzilla
+    link](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&component=replicate&f1=keywords&list_id=2816133&o1=nowords&product=GlusterFS&query_format=advanced&v1=Triaged)
+-   New distribute(DHT) bugs: [Bugzilla
+    links](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&component=distribute&f1=keywords&list_id=2816148&o1=nowords&product=GlusterFS&query_format=advanced&v1=Triaged)
+
+-   New bugs against version 3.6:
+    [<https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&product=GlusterFS&f1=keywords&f2=version&o1=nowords&o2=regexp&v1=Triaged&v2>=\^3.6
+    Bugzilla link]
+-   New bugs against version 3.5:
+    [<https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&product=GlusterFS&f1=keywords&f2=version&o1=nowords&o2=regexp&v1=Triaged&v2>=\^3.5
+    Bugzilla link]
+-   New bugs against version 3.4:
+    [<https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&product=GlusterFS&f1=keywords&f2=version&o1=nowords&o2=regexp&v1=Triaged&v2>=\^3.4
+    Bugzilla link]
+
+-   [<https://bugzilla.redhat.com/page.cgi?id=browse.html&product=GlusterFS&product_version>=&bug\_status=all&tab=recents
+    bugzilla tracker] (can include already Triaged bugs)
+
+-   [Untriaged NetBSD
+    bugs](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&keywords=Triaged&keywords_type=nowords&op_sys=NetBSD&product=GlusterFS)
+-   [Untriaged FreeBSD
+    bugs](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&keywords=Triaged&keywords_type=nowords&op_sys=FreeBSD&product=GlusterFS)
+-   [Untriaged Mac OS
+    bugs](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&keywords=Triaged&keywords_type=nowords&op_sys=Mac%20OS&product=GlusterFS)
+
+In addition to manually checking Bugzilla for bugs to triage, it is also
+possible to receive emails when new
+bugs are filed or existing bugs get updated.
+
+If at any point you feel like you do not know what to do with a certain
+report, please first ask [irc or mailing
+lists](http://www.gluster.org/community/index.html) before changing
+something.
+
+Is there enough information?
+----------------------------
+
+To make a report useful, the same rules apply as for
+[bug reporting guidelines](./Bug Reporting Guidelines.md).
+
+It's hard to generalize what makes a good report. For "average"
+reporters is definitely often helpful to have good steps to reproduce,
+GlusterFS software version , and information about the test/production
+environment, Linux/GNU distribution.
+
+If the reporter is a developer, steps to reproduce can sometimes be
+omitted as context is obvious. *However, this can create a problem for
+contributors that need to find their way, hence it is strongly advised
+to list the steps to reproduce an issue.*
+
+Other tips:
+
+-   There should be only one issue per report. Try not to mix related or
+    similar looking bugs per report.
+
+-   It should be possible to call the described problem fixed at some
+    point. "Improve the documentation" or "It runs slow" could never be
+    called fixed, while "Documentation should cover the topic Embedding"
+    or "The page at <http://en.wikipedia.org/wiki/Example> should load
+    in less than five seconds" would have a criterion. A good summary of
+    the bug will also help others in finding existing bugs and prevent
+    filing of duplicates.
+
+-   If the bug is a graphical problem, you may want to ask for a
+    screenshot to attach to the bug report. Make sure to ask that the
+    screenshot should not contain any confidential information.
+
+Is it a duplicate?
+------------------
+
+Some reports in Bugzilla have already been reported before so you can
+[search for an already existing
+report](https://bugzilla.redhat.com/query.cgi?format=advanced). We do
+not recommend to spend too much time on it; if a bug is filed twice,
+someone else will mark it as a duplicate later. If the bug is a
+duplicate, mark it as a duplicate in the resolution box below the
+comment field by setting the **CLOSED DUPLICATE** status, and shortly
+explain your action in a comment for the reporter. When marking a bug as
+a duplicate, it is required to reference the original bug.
+
+If you think that you have found a duplicate but you are not totally
+sure, just add a comment like "This bug looks related to bug XXXXX" (and
+replace XXXXX by the bug number) so somebody else can take a look and
+help judging.
+
+You can also take a look at
+https://bugzilla.redhat.com/page.cgi?id=browse.html&product=GlusterFS&product_version>=&bug\_status=all&tab=duplicates's
+list of existing duplicates
+
+Is it assigned to correct component of GlusterFS?
+-------------------------------------------------
+
+Make sure the bug is assigned on right component. Below are the list of
+GlusterFs components in bugzilla.
+
+-   access control - Access control translator
+-   BDB - Berkeley DB backend storage
+-   booster - LD\_PRELOAD'able access client
+-   build - Compiler, package management and platform specific warnings
+    and errors
+-   cli -gluster command line
+-   core - Core features of the filesystem
+-   distribute - Distribute translator (previously DHT)
+-   errorgen - Error Gen Translator
+-   fuse -mount/fuse translator and patched fuse library
+-   georeplication - Gluster Geo-Replication
+-   glusterd - Management daemon
+-   HDFS - Hadoop application support over GlusterFS
+-   ib-verbs - Infiniband verbs transport
+-   io-cache - IO buffer caching translator
+-   io-threads - IO threads performance translator
+-   libglusterfsclient- API interface to access glusterfs volumes
+    programatically
+-   locks - POSIX and internal locks
+-   logging - Centralized logging, log messages, log rotation etc
+-   nfs- NFS component in GlusterFS
+-   nufa- Non-Uniform Filesystem Scheduler Translator
+-   object-storage - Object Storage
+-   porting - Porting GlusterFS to different operating systems and
+    platforms
+-   posix - POSIX (API) based backend storage
+-   protocol -Client and Server protocol translators
+-   quick-read- Quick Read Translator
+-   quota - Volume & Directory quota translator
+-   rdma- RDMA transport
+-   read-ahead - Read ahead (file) performance translator
+-   replicate- Replication translator (previously AFR)
+-   rpc - RPC Layer
+-   scripts - Build scripts, mount scripts, etc.
+-   stat-prefetch - Stat prefetch translator
+-   stripe - Striping (RAID-0) cluster translator
+-   trace- Trace translator
+-   transport - Socket (IPv4, IPv6, unix, ib-sdp) and generic transport
+    code
+-   unclassified - Unclassified - to be reclassified as other components
+-   unify - Unify translator and schedulers
+-   write-behind- Write behind performance translator
+-   libgfapi - APIs for GlusterFS
+-   tests- GlusterFS Test Framework
+-   gluster-hadoop - Hadoop support on GlusterFS
+-   gluster-hadoop-install - Automated Gluster volume configuration for
+    Hadoop Environments
+-   gluster-smb - gluster smb
+-   puppet-gluster - A puppet module for GlusterFS
+
+Tips for searching:
+
+-   As it is often hard for reporters to find the right place (product
+    and component) where to file a report, also search for duplicates
+    outside same product and component of the bug report you are
+    triaging.
+-   Use common words and try several times with different combinations,
+    as there could be several ways to describe the same problem. If you
+    choose the proper and common words, and you try several times with
+    different combinations of those, you ensure to have matching
+    results.
+-   Drop the ending of a verb (e.g. search for "delet" so you get
+    reports for both "delete" and "deleting"), and also try similar
+    words (e.g. search both for "delet" and "remov").
+-   Search using the date range delimiter: Most of the bug reports are
+    recent, so you can try to increase the search speed using date
+    delimiters by going to "Search by Change History" on the [search
+    page](https://bugzilla.redhat.com/query.cgi?format=advanced).
+    Example: search from "2011-01-01" or "-730d" (to cover the last two
+    years) to "Now".
+
+Are the fields correct?
+-----------------------
+
+### Summary
+
+Sometimes the summary does not summarize the bug itself well. You may
+want to update the bug summary to make the report distinguishable. A
+good title may contain:
+
+-   A brief explanation of the root cause (if it was found)
+-   Some of the symptoms people are experiencing
+
+### Adding people to the "CC" or changing the "Assigned to" field
+
+Normally, developers and potential assignees of an area are already
+CC'ed by default, but sometimes reports describe general issues or are
+filed against common bugzilla products. Only if you know developers who
+work in the area covered by the bug report, and if you know that these
+developers accept getting CCed or assigned to certain reports, you can
+add that person to the CC field or even assign the bug report to
+her/him.
+
+To get an idea who works in which area, check To know component owners ,
+you can check the "MAINTAINERS" file in root of glusterfs code directory
+or querying changes in [Gerrit](http://review.gluster.org) (see
+[Simplified dev workflow](./Simplified Development Workflow.md))
+
+### Severity And Priority
+
+Please see below for information on the available values and their
+meanings.
+
+#### Severity
+
+This field is a pull-down of the external weighting of the bug report's
+importance and can have the following values:
+
+  Severity     |Definition
+  -------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------
+  urgent       |catastrophic issues which severely impact the mission-critical operations of an organization. This may mean that the operational servers, development systems or customer applications are down or not functioning and no procedural workaround exists.
+  high         |high-impact issues in which the customer's operation is disrupted, but there is some capacity to produce
+  medium       |partial non-critical functionality loss, or issues which impair some operations but allow the customer to perform their critical tasks. This may be a minor issue with limited loss or no loss of functionality and limited impact to the customer's functionality
+  low          |general usage questions, recommendations for product enhancement, or development work
+  unspecified  |importance not specified
+
+#### Priority
+
+This field is a pull-down of the internal weighting of the bug report's
+importance and can have the following values:
+
+  Priority     |Definition
+  -------------|------------------------
+  urgent       |extremely important
+  high         |very important
+  medium       |average importance
+  low          |not very important
+  unspecified  |importance not specified
+
+
+### Bugs present in multiple Versions
+
+During triaging you might come across a particular bug which is present
+across multiple version of GlusterFS. Here are the course of actions:
+
+-   We should have separate bugs for each release (We should
+    clone bugs if required)
+-   Bugs in released versions should be depended on bug for mainline
+    (master branch) if the bug is applicable for mainline.
+    -   This will make sure that the fix would get merged in master
+        branch first then the fix can get ported to other stable
+        releases.
+
+*Note: When a bug depends on other bugs, that means the bug cannot be
+fixed unless other bugs are fixed (depends on), or this bug stops other
+bugs being fixed (blocks)*
+
+Here are some examples:
+
+-   A bug is raised for GlusterFS 3.5 and the same issue is present in
+    mainline (master branch) and GlusterFS 3.6
+    -   Clone the original bug for mainline.
+    -   Clone another for 3.6.
+    -   And have the GlusterFS 3.6 bug and GlusterFS 3.5 bug 'depend on'
+        the 'mainline' bug
+
+-   A bug is already present for mainline, and the same issue is seen in
+    GlusterFS 3.5.
+    -   Clone the original bug for GlusterFS 3.5.
+    -   And have the cloned bug (for 3.5) 'depend on' the 'mainline'
+        bug.
+
+### Keywords
+
+Many predefined searches for Bugzilla include keywords. One example are
+the searches for the triaging. If the bug is 'NEW' and 'Triaged' is no
+set, you (as a triager) can pick it and use this page to triage it. When
+the bug is 'NEW' and 'Triaged' is in the list of keyword, the bug is
+ready to be picked up by a developer.
+
+**Triaged**
+:   Once you are done with triage add the **Triaged** keyword to the
+    bug, so that others will know the triaged state of the bug. The
+    predefined search at the top of this page will then not list the
+    Triaged bug anymore. Instead, the bug should have moved to [this
+    list](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&keywords=Triaged&product=GlusterFS).
+
+**EasyFix**
+:   By adding the **EasyFix** keyword, the bug gets added to the [list
+    of bugs that should be simple to fix](./Easy Fix Bugs.md).
+    Adding this keyword is encouraged for simple and well defined bugs
+    or feature enhancements.
+
+**Patch**
+:   When a patch for the problem has been attached or included inline,
+    add the **Patch** keyword so that it is clear that some preparation
+    for the development has been done already. If course, it would have
+    been nicer if the patch was sent to Gerrit for review, but not
+    everyone is ready to pass the Gerrit hurdle when they report a bug.
+ 
+You can also add the **Patch** keyword when a bug has been fixed in
+    mainline and the patch(es) has been identified. Add a link to the
+    Gerrit change(s) so that backporting to a stable release is made
+    simpler.
+
+**Documentation**
+:   Add the **Documentation** keyword when a bug has been reported for
+    the documentation. This helps editors and writers in finding the
+    bugs that they can resolve.
+
+**Tracking**
+:   This keyword is used for bugs which are used to track other bugs for
+    a particular release. For example [3.6 tracker
+    bug](https://bugzilla.redhat.com/showdependencytree.cgi?maxdepth=2&hide_resolved=1&id=glusterfs-3.6.0)
+
+**FutureFeature**
+:   This keyword is used for bugs which are used to request for a
+    feature enhancement ( RFE - Requested Feature Enhancement) for
+    future releases of GlusterFS. If you open a bug by requesting a
+    feature which you would like to see in next versions of GlusterFS
+    please report with this keyword.
+
+Add yourself to the CC list
+---------------------------
+
+By adding yourself to the CC list of bug reports that you change, you
+will receive followup emails with all comments and changes by anybody on
+that individual report. This helps learning what further investigations
+others make. You can change the settings in Bugzilla on which actions
+you want to receive mail.
+
+Bugs For Group Triage
+---------------------
+
+If you come across a bug/ bugs or If you think any bug should to go
+thorough the bug triage group, please set NEEDINFO for bugs@gluster.org
+on the bug.
+
+Resolving bug reports
+---------------------
+
+See the [Bug report life cycle](./Bug report Life Cycle.md) for
+the meaning of the bug status and resolutions.
+
+Example of Triaged Bugs
+-----------------------
+
+This Bugzilla
+[filter](https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&keywords=Triaged&keywords_type=anywords&list_id=2739593&product=GlusterFS&query_format=advanced)
+will list NEW, Triaged Bugs

--- a/Workflow-Guide/Bug-report-Life-Cycle.md
+++ b/Workflow-Guide/Bug-report-Life-Cycle.md
@@ -1,0 +1,57 @@
+This page describes the life of a bug report.
+
+-   When a bug is first reported, it is given the **NEW** status.
+-   Once a developer has started, or is planning to work on a bug, the
+    status **ASSIGNED** is set. The "Assigned to" field should mention a
+    specific developer.
+-   If an initial
+    [patch](https://en.wikipedia.org/wiki/Patch_(computing)) for a bug
+    has been put into the [Gerrit code review
+    tool](http://review.gluster.org), the status **POST** should be set
+    manually. The status **POST** should only be used when all patches
+    for a specific bug have been posted for review.
+-   After a review of the patch, and passing any automated regression
+    tests, the patch will get merged by one of the maintainers. When the
+    patch has been merged into the git repository, a comment is added to
+    the bug. Only when all needed patches have been merged, the assigned
+    engineer will need to change the status to **MODIFIED**.
+-   Once a package is available with fix for the bug, the status should
+    be moved to **ON\_QA**.
+    -   The **Fixed in version** field should get the name/release of
+        the package that contains the fix. Packages for multiple
+        distributions will mostly get available within a few days after
+        the *make dist* tarball was created.
+    -   This tells the bug reporter that a package is available with fix
+        for the bug and that they should test the package.
+    -   The release maintainer need to do this change to bug status,
+        scripts are available (ask *ndevos*).
+-   The status **VERIFIED** is set if a QA tester or the reporter
+    confirmed the fix after fix is merged and new build with the fix
+    resolves the issue.
+-   In case the version does not fix the reported bug, the status should
+    be moved back to **ASSIGNED** with a clear note on what exactly
+    failed.
+-   When a report has been solved it is given **CLOSED** status. This
+    can mean:
+    -   **CLOSED/CURRENTRELEASE** when a code change that fixes the
+        reported problem has been merged in
+        [Gerrit](http://review.gluster.org).
+    -   **CLOSED/WONTFIX** when the reported problem or suggestion is
+        valid, but any fix of the reported problem or implementation of
+        the suggestion would be barred from approval by the project's
+        Developers/Maintainers (or product managers, if existing).
+    -   **CLOSED/WORKSFORME** when the problem can not be reproduced,
+        when missing information has not been provided, or when an
+        acceptable workaround exists to achieve a similar outcome as
+        requested.
+    -   **CLOSED/CANTFIX** when the problem is not a bug, or when it is
+        a change that is outside the power of GlusterFS development. For
+        example, bugs proposing changes to third-party software can not
+        be fixed in the GlusterFS project itself.
+    -   **CLOSED/DUPLICATE** when the problem has been reported before,
+        no matter if the previous report has been already resolved or
+        not.
+
+If a bug report was marked as *CLOSED* or *VERIFIED* and it turns out
+that this was incorrect, the bug can be changed to the status *ASSIGNED*
+or *NEW*.

--- a/Workflow-Guide/Bug-reporting-template.md
+++ b/Workflow-Guide/Bug-reporting-template.md
@@ -1,0 +1,55 @@
+Template for bug description
+----------------------------
+This template should be in-line to the [Bug reporting guidelines](./Bug Reporting Guidelines.md).
+The template is replacement for the default description template present in [Bugzilla](https://bugzilla.redhat.com)
+
+    work in progress
+
+------------------------------------------------------------------------
+
+Description of problem:
+
+Version of GlusterFS package installed:
+
+Location from which the packages are used:
+
+GlusterFS Cluster Information:
+
+-   Number of volumes
+-   Volume Names
+-   Volume on which the particular issue is seen [ if applicable ]
+-   Type of volumes
+-   Volume options if available
+-   Output of `gluster volume info`
+-   Output of `gluster volume status`
+-   Get the statedump of the volume with the problem
+
+`   $ gluster volume statedump `<vol-name>
+
+-   Client Information
+    -   OS Type:
+    -   Mount type:
+    -   OS Version:
+
+How reproducible:
+
+Steps to Reproduce:
+
+-   1.
+-   2.
+-   3.
+
+Actual results:
+
+Expected results:
+
+Logs Information:
+
+-   Provide possible issues, warnings, errors as a comment to the bug
+    -   Look for issues/warnings/errors in self-heal logs, rebalance logs, glusterd logs, brick logs, mount logs/nfs logs/smb logs
+    -   Add the entire logs as attachment, if it is very large to paste as a comment
+
+Additional info:
+
+  [Bug\_reporting\_guidelines]: Bug_reporting_guidelines "wikilink"
+  [Bugzilla]: https://bugzilla.redhat.com

--- a/Workflow-Guide/GlusterFS-Release-process.md
+++ b/Workflow-Guide/GlusterFS-Release-process.md
@@ -1,0 +1,73 @@
+Release Process for GlusterFS
+=============================
+
+Create tarball
+--------------
+
+1.  Add the release-notes to the docs/release-notes/ directory in the
+    sources
+2.  after merging the release-notes, create a tag like v3.6.2
+3.  push the tag to git.gluster.org
+4.  create the tarball with the [release job in
+    Jenkins](http://build.gluster.org/job/release/)
+
+Notify packagers
+----------------
+
+Notify the packagers that we need packages created. Provide the link to the
+source tarball from the Jenkins release job to the [packagers
+mailinglist](mailto:packaging@gluster.org). A list of the people involved in
+the package maintenance for the different distributions is in the `MAINTAINERS`
+file in the sources.
+
+Create a new Tracker Bug for the next release
+---------------------------------------------
+
+The tracker bugs are used as guidance for blocker bugs and should get created when a release is made. To create one
+
+- file a [new bug in Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=GlusterFS)
+- base the contents on previous tracker bugs, like the one for [glusterfs-3.5.5](https://bugzilla.redhat.com/show_bug.cgi?id=glusterfs-3.5.5)
+- set the '''Alias''' (it is a text-field) of the bug to 'glusterfs-a.b.c' where a.b.c is the next minor version
+- save the new bug
+- you should now be able to use the 'glusterfs-a.b.c' to access the bug, use the alias to replace the BZ# in URLs, or '''blocks''' fields
+- bugs that were not fixed in this release, but were added to the tracker should be moved to the new tracker
+
+
+Create Release Announcement
+---------------------------
+
+Create the Release Announcement (this is often done while people are
+making the packages). The contents of the release announcement can be
+based on the release notes, or should at least have a pointer to them.
+
+Examples:
+
+-   [blog](http://blog.gluster.org/2014/11/glusterfs-3-5-3beta2-is-now-available-for-testing/)
+-   [release
+    notes](https://github.com/gluster/glusterfs/blob/v3.5.3/doc/release-notes/3.5.3.md)
+
+Send Release Announcement
+-------------------------
+
+Once the Fedora/EL RPMs are ready (and any others that are ready by
+then), send the release announcement:
+
+-   Gluster Mailing lists
+    -   gluster-announce, gluster-devel, gluster-users
+-   Gluster Blog
+-   Gluster Twitter account
+-   Gluster Facebook page
+-   Gluster LinkedIn group - Justin has access
+-   Gluster G+
+
+Close Bugs
+----------
+
+Close the bugs that have all their patches included in the release.
+Leave a note in the bug report with a pointer to the release
+announcement.
+
+Other things to consider
+------------------------
+
+-   Translations? - Are there strings needing translation?

--- a/Workflow-Guide/Guidelines-For-Maintainers.md
+++ b/Workflow-Guide/Guidelines-For-Maintainers.md
@@ -1,0 +1,70 @@
+### Guidelines For Maintainers
+
+GlusterFS has maintainers, sub-maintainers and release maintainers to
+manage the project's codebase. Sub-maintainers are the owners for
+specific areas/components of the source tree. Maintainers operate across
+all components in the source tree.Release maintainers are the owners for
+various release branches (release-x.y) present in the GlusterFS
+repository.
+
+In the guidelines below, release maintainers and sub-maintainers are
+also implied when there is a reference to maintainers unless it is
+explicitly called out.
+
+### Guidelines that Maintainers are expected to adhere to
+
+​1. Ensure qualitative and timely management of patches sent for review.
+
+​2. For merging patches into the repository, it is expected of
+maintainers to:
+
+		a> Merge patches of owned components only.
+		b> Seek approvals from all maintainers before merging a patchset spanning multiple components.
+		c> Ensure that regression tests pass for all patches before merging.
+		d> Ensure that regression tests accompany all patch submissions.
+		e> Ensure that documentation is updated for a noticeable change in user perceivable behavior or design.
+		f> Encourage code unit tests from patch submitters to improve the overall quality of the codebase.
+		g> Not merge patches written by themselves until there is a +2 Code Review vote by other reviewers.
+
+​3. The responsibility of merging a patch into a release branch in
+normal circumstances will be that of the release maintainer's. Only in
+exceptional situations, maintainers & sub-maintainers will merge patches
+into a release branch.
+
+​4. Release maintainers will ensure approval from appropriate
+maintainers before merging a patch into a release branch.
+
+​5. Maintainers have a responsibility to the community, it is expected
+of maintainers to:
+
+		a> Facilitate the community in all aspects.
+		b> Be very active and visible in the community.
+		c> Be objective and consider the larger interests of the community  ahead of individual interests.
+		d> Be receptive to user feedback.
+		e> Address concerns & issues affecting users.
+		f> Lead by example.
+
+### Queries on Guidelines
+
+Any questions or comments regarding these guidelines can be routed to
+gluster-devel at gluster dot org.
+
+### Patches in Gerrit
+
+Gerrit can be used to list patches that need reviews and/or can get
+merged. Some queries have been prepared for this, edit the search box in
+Gerrit to make your own variation:
+
+-   [3.5 open reviewed/verified (non
+    rfc)](http://review.gluster.org/#/q/project:glusterfs+branch:release-3.5+status:open+%28label:Code-Review%253D%252B1+OR+label:Code-Review%253D%252B2+OR+label:Verified%253D%252B1%29+NOT+topic:rfc+NOT+label:Code-Review%253D-2,n,z)
+-   [All open 3.5 patches (non
+    rfc)](http://review.gluster.org/#/q/project:glusterfs+branch:release-3.5+status:open+NOT+topic:rfc,n,z)
+-   [Open NFS (master
+    branch)](http://review.gluster.org/#/q/project:glusterfs+branch:master+status:open+message:nfs,n,z)
+
+An other option can be used in combination with the Gerrit queries, and
+has support for filename/directory matching (the queries above do not).
+Go to the [settings](http://review.gluster.org/#/settings/projects) in
+your Gerrit profile, and enter filters like these:
+
+![gerrit-watched-projects](https://cloud.githubusercontent.com/assets/10970993/7411584/1a26614a-ef57-11e4-99ed-ee96af22a9a1.png)

--- a/Workflow-Guide/Index.md
+++ b/Workflow-Guide/Index.md
@@ -1,0 +1,12 @@
+# Workflow Guide
+
+1. Bug Guidelines
+	
+	* [Bug Reporting Guidelines](./Bug-Reporting-Guidelines.md)
+	* [Bug Reporting Template](./Bug-reporting-template.md)
+	* [Bug report Cycle](./Bug-report-Life-Cycle.md)
+	* [Bug Triage](./Bug-Triage.md)
+
+2. [GlusterFS Release process](./GlusterFS-Release-process.md)
+
+3. [Guidelines For Maintainers](./Guidelines-For-Maintainers.md)

--- a/index.md
+++ b/index.md
@@ -33,6 +33,8 @@ Install Guide.
 
 -  [Troubleshooting Guide](./Troubleshooting/README.md) - Guide for troubleshooting.
 
+-  [Workflow-Guide](./Workflow-Guide/Index.md) - Guide for workflows
+
 **How to Contribute?**
 
 The Gluster documentation has its home on GitHub, and the easiest way to contribute is to use 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,14 @@ pages:
   - Export and Netgroup Authentication: Administrator Guide/Export And Netgroup Authentication.md
 - Developers Guide:
   - Developers Home: Developer-guide/Developers Index.md
+- Workflow-Guide:
+  - Index: Workflow-Guide/Index.md
+  - Bug Reporting Guidelines : Workflow-Guide/Bug-Reporting-Guidelines.md
+  - Bug Reporting Template : Workflow-Guide/Bug-reporting-template.md
+  - Bug report Cycle : Workflow-Guide/Bug-report-Life-Cycle.md
+  - Bug Triage : Workflow-Guide/Bug-Triage.md
+  - GlusterFS Release process : Workflow-Guide/GlusterFS-Release-process.md
+  - Guidelines For Maintainers : Workflow-Guide/Guidelines-For-Maintainers.md
 - Upgrade-Guide:
   - Upgrade-Guide Index: Upgrade-Guide/README.md
   - Upgrade to 3.5: Upgrade-Guide/upgrade_to_3.5.md


### PR DESCRIPTION
This patch adds a new directory "Workflow-Guide"
and few files were added to it which were more
alligned to workflows rather than developer-guide.

These files were copied from
"https://github.com/gluster/glusterfs/tree/master/doc/developer-guide"

index.md and mkdocs.yml were also updated to reflect the change.

Signed-off-by: Bipin Kunal <kunalbipin@gmail.com>