### PR TITLE
bug-triage: fix broken link to the "Bug report cycle"

### DIFF
--- a/Contributors-Guide/Bug-Triage.md
+++ b/Contributors-Guide/Bug-Triage.md
@@ -389,7 +389,7 @@ on the bug.
 Resolving bug reports
 ---------------------
 
-See the [Bug report life cycle](./Bug report Life Cycle.md) for
+See the [Bug report life cycle](./Bug-report-Life-Cycle.md) for
 the meaning of the bug status and resolutions.
 
 Example of Triaged Bugs


### PR DESCRIPTION
Signed-off-by: Niels de Vos <ndevos@redhat.com>