### PR TITLE
A typo?

### DIFF
--- a/Troubleshooting/split-brain.md
+++ b/Troubleshooting/split-brain.md
@@ -199,7 +199,7 @@ Hence execute
 
 On /gfs/brick-a/a:  
 For trusted.afr.vol-client-1  
-0x0000000000000000ffffffff to 0x000003d70000000000000000  
+0x000003d70000000100000000 to 0x000003d70000000000000000  
 (Note that the data part is still not all zeros)  
 Hence execute  
 `setfattr -n trusted.afr.vol-client-1 -v 0x000003d70000000000000000 /gfs/brick-a/a`


### PR DESCRIPTION
The place in question talks about making gluster believe that the metadata of file `a` on `brick-b` should win. Thus brick `a` should see the metadata changelog of brick `b` to be normal but taking the previous value (`0x000003d70000000100000000`), leave the data log dirty (`000003d7`) and unset the metadata part `00000001`. The `0000000000000000ffffffff` seems to be wrong.