### PR TITLE
admin-guide: add link to 'Handling of users that belong to many groups'

### DIFF
--- a/Administrator Guide/index.md
+++ b/Administrator Guide/index.md
@@ -19,6 +19,7 @@
 4.  [POSIX Access Control Lists](./Access Control Lists.md)
 
 5.  [Accessing Data - Setting Up Clients](./Setting Up Clients.md)
+	*  [Handling of users that belong to many groups](./Handling-of-users-with-many-groups.md)
 
 6.  Volume Options
 


### PR DESCRIPTION
The page titles "Handling of users that belong to many groups" does not seem to
be listed in the Administrator Guide. Users can not find this page on RTD
without it.

Signed-off-by: Niels de Vos <ndevos@redhat.com>