### PR TITLE
Add missing doc for trash translator

### DIFF
--- a/Administrator Guide/Trash.md
+++ b/Administrator Guide/Trash.md
@@ -1,0 +1,78 @@
+Trash Translator
+================
+Trash translator will allow users to access deleted or truncated files. Every brick will maintain a hidden .trashcan directory , which will be used to store the files deleted or truncated from the respective brick .The aggreagate of all those .trashcan directory can be accesed from the mount point. In order to avoid name collisions , a time stamp is appended to the original file name while it is being moved to trash directory.
+
+## Implications and Usage
+Apart from the primary use-case of accessing files deleted or truncated by user , the trash translator can be helpful for internal operations such as self-heal and rebalance. During self-heal and rebalance it is possible to lose crucial data. In those circumstances the trash translator can assist in recovery of the lost data. The trash translator is designed to intercept unlink, truncate and ftruncate fops, store a copy of the current file in the trash directory, and then perform the fop on the original file. For the internal operations , the files are stored under 'internal_op' folder inside trash directory.
+
+## Volume Options
+
+* ***gluster volume set &lt;VOLNAME> features.trash &lt;on / off>***
+
+    This command can be used to enable trash translator in a volume. If set to on, trash directory will be created in every brick inside the volume during volume start command. By default translator is loaded during volume start but remains non-functional. Disabling trash with the help of this option will not remove the trash directory or even its contents from the volume.
+
+* ***gluster volume set &lt;VOLNAME> features.trash-dir &lt;name>***
+
+    This command is used to reconfigure the trash directory to a user specified name. The argument is a valid directory name. Directory will be created inside every brick under this name. If not specified by the user, the trash translator will create the trash directory with the default name “.trashcan”. This can be used only when trash-translator is on.
+
+* ***gluster volume set &lt;VOLNAME> features.trash-max-filesize &lt;size>***
+
+    This command can be used to filter files entering trash directory based on their size. Files above trash_max_filesize are deleted/truncated directly. Value for size may be followed by mutliplicative suffixes as KB(=1024 bytes), MB(=1024\*1024 bytes) and GB(=1024\*1024\*1024 bytes). Default size is set to 5MB. Considering the fact that trash directory is consuming the glusterfs volume space, trash feature is implemented to function in such a way that it directly deletes/truncates files with size > 1GB even if this option is set to some value greater than 1GB.
+
+* ***gluster volume set &lt;VOLNAME> features.trash-eliminate-path &lt;path1> [ , &lt;path2> , . . . ]***
+
+    This command can be used to set the eliminate pattern for the trash translator. Files residing under this pattern will not be moved to trash directory during deletion/truncation. Path must be a valid one present in volume.
+
+* ***gluster volume set &lt;VOLNAME> features.trash-internal-op &lt;on / off>***
+
+    This command can be used to enable trash for internal operations like self-heal and re-balance. By default set to off.
+
+## Sample usage
+Following steps give illustrates a simple scenario of deletion of file from directory
+
+1. Create a simple distribute volume and start it.
+
+        # gluster volume create test rhs:/home/brick
+        # gluster volume start test
+
+2. Enable trash translator
+
+        # gluster volume set test features.trash on
+
+3. Mount glusterfs volume via native client as follows.
+
+        # mount -t glusterfs  rhs:test /mnt
+
+4. Create a directory and file in the mount.
+
+        # mkdir mnt/dir
+        # echo abc > mnt/dir/file
+
+5. Delete the file from the mount.
+
+        # rm mnt/dir/file -rf
+
+6. Checkout inside the trash directory.
+
+        # ls mnt/.trashcan
+
+We can find the deleted file inside the trash directory with timestamp appending on its filename.
+
+For example,
+
+        [root@rh-host ~]# mount -t glusterfs rh-host:/test /mnt/test
+        [root@rh-host ~]# mkdir /mnt/test/abc
+        [root@rh-host ~]# touch /mnt/test/abc/file
+        [root@rh-host ~]# rm /mnt/test/abc/file
+        remove regular empty file ‘/mnt/test/abc/file’? y
+        [root@rh-host ~]# ls /mnt/test/abc
+        [root@rh-host ~]#
+        [root@rh-host ~]# ls /mnt/test/.trashcan/abc/
+        file2014-08-21_123400
+
+##### Points to be remembered
+* As soon as the volume is started, trash directory will be created inside the volume and will be visible through mount. Disabling trash will not have any impact on its visibilty from the mount.
+* Eventhough deletion of trash-directory is not permitted, currently residing trash contents will be removed on issuing delete on it and only an empty trash-directory exists.
+
+##### Known issue
+Since trash translator resides on the server side higher translator like AFR, DHT are unaware of rename and truncate operations being done by this translator which eventually moves the files to trash directory. Unless and until a complete-path-based lookup comes on trashed files, those may not be visible from the mount.

--- a/Administrator Guide/index.md
+++ b/Administrator Guide/index.md
@@ -69,7 +69,9 @@
 
 21.  [Arbiter volumes and quorum options](./arbiter-volumes-and-quorum.md)
 
-22.  Appendices
+22.  [Trash for GlusterFS](./Trash.md)
+
+23.  Appendices
 
 	*  [Troubleshooting](./Troubleshooting.md)
 	*  [Network Configurations Techniques](./Network Configurations Techniques.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ pages:
   - Export and Netgroup Authentication: Administrator Guide/Export And Netgroup Authentication.md
   - Configuring NFS-Ganesha server: Administrator Guide/NFS-Ganesha GlusterFS Intergration.md
   - Arbiter volumes and quorum options: Administrator Guide/arbiter-volumes-and-quorum.md
+  - Trash for GlusterFS: Administrator Guide/Trash.md
 - Developers Guide:
   - Developers Home: Developer-guide/Developers-Index.md
   - Simplified Development Workflow : Developer-guide/Simplified-Development-Workflow.md


### PR DESCRIPTION
Admin guide for trash feature was already present from the time it was accepted to 3.7 release and is available under gluster-specs.

https://github.com/gluster/glusterfs-specs/blob/master/done/Features/trash_xlator.md

But due to revamp done to readthedocs this was not migrated to exact location.

Signed-off-by: Anoop C S <anoopcs@redhat.com>