### PR TITLE
Fix warnings

### DIFF
--- a/Contributors-Guide/Bug-Reporting-Guidelines.md
+++ b/Contributors-Guide/Bug-Reporting-Guidelines.md
@@ -33,7 +33,7 @@ Reporting A Bug
 -   Here is the link to file a bug:
     [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=GlusterFS)
 -   The template for filing a bug can be found [
-    *here*](./Bug reporting template.md)
+    *here*](./Bug-Reporting-Guidelines.md)
 
 *Note: Please go through all below sections to understand what
 information we need to put in a bug. So it will help the developer to

--- a/Contributors-Guide/Bug-Triage.md
+++ b/Contributors-Guide/Bug-Triage.md
@@ -101,7 +101,7 @@ Is there enough information?
 ----------------------------
 
 To make a report useful, the same rules apply as for
-[bug reporting guidelines](./Bug Reporting Guidelines.md).
+[bug reporting guidelines](./Bug-Reporting-Guidelines.md).
 
 It's hard to generalize what makes a good report. For "average"
 reporters is definitely often helpful to have good steps to reproduce,
@@ -254,7 +254,7 @@ her/him.
 To get an idea who works in which area, check To know component owners ,
 you can check the "MAINTAINERS" file in root of glusterfs code directory
 or querying changes in [Gerrit](http://review.gluster.org) (see
-[Simplified dev workflow](./Simplified Development Workflow.md))
+[Simplified dev workflow](/Developer-guide/Simplified-Development-Workflow.md))
 
 ### Severity And Priority
 
@@ -337,7 +337,7 @@ ready to be picked up by a developer.
 
 **EasyFix**
 :   By adding the **EasyFix** keyword, the bug gets added to the [list
-    of bugs that should be simple to fix](./Easy Fix Bugs.md).
+    of bugs that should be simple to fix](/Developer-guide/Easy-Fix-Bugs.md).
     Adding this keyword is encouraged for simple and well defined bugs
     or feature enhancements.
 
@@ -347,7 +347,7 @@ ready to be picked up by a developer.
     for the development has been done already. If course, it would have
     been nicer if the patch was sent to Gerrit for review, but not
     everyone is ready to pass the Gerrit hurdle when they report a bug.
- 
+
 You can also add the **Patch** keyword when a bug has been fixed in
     mainline and the patch(es) has been identified. Add a link to the
     Gerrit change(s) so that backporting to a stable release is made

--- a/Contributors-Guide/Bug-reporting-template.md
+++ b/Contributors-Guide/Bug-reporting-template.md
@@ -1,6 +1,6 @@
 Template for bug description
 ----------------------------
-This template should be in-line to the [Bug reporting guidelines](./Bug Reporting Guidelines.md).
+This template should be in-line to the [Bug reporting guidelines](./Bug-Reporting-Guidelines.md).
 The template is replacement for the default description template present in [Bugzilla](https://bugzilla.redhat.com)
 
     work in progress

--- a/Developer-guide/Backport-Guidelines.md
+++ b/Developer-guide/Backport-Guidelines.md
@@ -5,7 +5,7 @@ fix to stable branch.
 
 Anyone in the community can suggest a backport. If you are interested to
 suggest a backport, please check the [Backport
-Wishlist](./Backport Wishlist.md).
+Wishlist](./Backport-Wishlist.md).
 
 This page describes the steps needed to backport simple changes. Changes
 that do not apply cleanly will need some manual modifications and using

--- a/Developer-guide/Building-GlusterFS.md
+++ b/Developer-guide/Building-GlusterFS.md
@@ -145,4 +145,4 @@ will need to install the rpmbuild requirements including rpmbuild and
 mock)*
 
 A more detailed description for building RPMs can be found at
-[CompilingRPMS](./Compiling RPMS.md).
+[CompilingRPMS](./Compiling-RPMS.md).

--- a/Developer-guide/Development-Workflow.md
+++ b/Developer-guide/Development-Workflow.md
@@ -5,7 +5,7 @@ This document provides a detailed overview of the development model
 followed by the GlusterFS project.
 
 For a simpler overview visit
-[Simplified develoment workflow](./Simplified Development Workflow.md).
+[Simplified develoment workflow](./Simplified-Development-Workflow.md).
 
 Basics
 ------
@@ -157,7 +157,7 @@ Building
 ### Environment Setup
 
 **For details about the required packages for the build environment
-refer : [Building GlusterFS](./Building GlusterFS.md)**
+refer : [Building GlusterFS](./Building-GlusterFS.md)**
 
 Ubuntu:
 
@@ -172,7 +172,7 @@ command to install the required packages:
 CentOS/RHEL/Fedora:
 
 On Fedora systems, install the required packages by following the
-instructions in [CompilingRPMS](./Compiling RPMS.md).
+instructions in [CompilingRPMS](./Compiling-RPMS.md).
 
 ### Creating build environment
 
@@ -197,14 +197,14 @@ CentOS/RHEL/Fedora:
 
 In an rpm based system, there are two methods to build GlusterFS. One is
 to use the method describe above for *Ubuntu*. The other is to build and
-install RPMS as described in [CompilingRPMS](./Compiling RPMS.md).
+install RPMS as described in [CompilingRPMS](./Compiling-RPMS.md).
 
 #### GlusterFS UFO/SWIFT
 
 To build and run Gluster UFO you can do the following:
 
 1.  Build, create, and install the RPMS as described in
-    [CompilingRPMS](./Compiling RPMS.md).
+    [CompilingRPMS](./Compiling-RPMS.md).
 2.  Configure UFO/SWIFT as described in [Howto Using UFO SWIFT - A quick
     and dirty setup
     guide](http://www.gluster.org/2012/09/howto-using-ufo-swift-a-quick-and-dirty-setup-guide)

--- a/Developer-guide/Easy-Fix-Bugs.md
+++ b/Developer-guide/Easy-Fix-Bugs.md
@@ -10,7 +10,7 @@ Gluster.
     -   When you pick an EasyFix you want to work on, assign it to
         yourself and move it to ASSIGNED
     -   Check
-        [Bug report life cycle](./Bug report Life Cycle.md) and
+        [Bug report life cycle](/Contributors-Guide/Bug-report-Life-Cycle.md) and
         follow it.
     -   Check Developers page for details about development workflow,
         GlusterFS design documents etc.

--- a/Developer-guide/Fixing-issues-reported-by-tools-for-static-code-analysis.md
+++ b/Developer-guide/Fixing-issues-reported-by-tools-for-static-code-analysis.md
@@ -2,7 +2,7 @@ Static Code Analysis Tools
 --------------------------
 
 Bug fixes for issues reported by *Static Code Analysis Tools* should
-follow [Development Work Flow](./Development Workflow.md)
+follow [Development Work Flow](./Development-Workflow.md)
 
 ### Coverity
 

--- a/Developer-guide/Simplified-Development-Workflow.md
+++ b/Developer-guide/Simplified-Development-Workflow.md
@@ -5,7 +5,7 @@ This page gives a simplified model of the development workflow used by
 the GlusterFS project. This will give the steps required to get a patch
 accepted into the GlusterFS source.
 
-Visit [Development Work Flow](./Development Workflow.md) a more
+Visit [Development Work Flow](./Development-Workflow.md) a more
 detailed description of the workflow.
 
 Initial preperation
@@ -36,7 +36,7 @@ To generate a key pair do,
 and follow the instructions.
 
 Next, install the build requirements for GlusterFS. Refer
-[Building GlusterFS - Build Requirements](./Building GlusterFS.md#Build Requirements)
+[Building GlusterFS - Build Requirements](./Building-GlusterFS.md#Build Requirements)
 for the actual requirements.
 
 ### Gerrit setup
@@ -79,7 +79,7 @@ branch, first checkout the upstream branch you want to work on and
 update it. More details on the upstream branching model for GlusterFS
 can be found at
 
-[Development Work Flow - Branching\_policy](./Development Workflow.md#branching-policy).
+[Development Work Flow - Branching\_policy](./Development-Workflow.md#branching-policy).
 For example if you want to develop on the master branch,
 
 		$ git checkout master
@@ -109,9 +109,9 @@ Unless your changes are very minor and trivial, you should also add a
 test for your change. Tests are used to ensure that the changes you did
 are not broken inadvertently. More details on tests can be found at
 
-[Development Workflow - Test cases](./Development Workflow.md#test-cases)
+[Development Workflow - Test cases](./Development-Workflow.md#test-cases)
 and
-[Development Workflow - Regression tests and test cases](./Development Workflow.md#regression-tests-and-test-cases)
+[Development Workflow - Regression tests and test cases](./Development-Workflow.md#regression-tests-and-test-cases)
 
 ### Regression test
 
@@ -139,7 +139,7 @@ Now, commit these changes using
 Provide a meaningful commit message. The commit message policy is
 described at
 
-[Development Work Flow - Commit policy](./Development Workflow.md#commit-policy).
+[Development Work Flow - Commit policy](./Development-Workflow.md#commit-policy).
 
 It is essential that you commit with the '-s' option, which will
 sign-off the commit with your configured email, as gerrit is configured
@@ -159,7 +159,7 @@ If the patch is submitted for review, the rfc.sh script will return the
 gerrit url for the review request.
 
 More details on the rfc.sh script are available at
-[Development Work Flow - rfc.sh](./Development Workflow.md#rfc.sh).
+[Development Work Flow - rfc.sh](./Development-Workflow.md#rfc.sh).
 
 Review process
 --------------
@@ -181,7 +181,7 @@ associated bug-id.
 
 More details can be found at
 
-[Development Work Flow - Auto verification](./Development Workflow.md#auto-verification).
+[Development Work Flow - Auto verification](./Development-Workflow.md#auto-verification).
 
 ### Formal review
 
@@ -193,9 +193,9 @@ comments on the reasons.
 More information regarding the review qualifiers and disqualifiers is
 available at
 
-[Development Work Flow - Submission Qualifiers](./Development Workflow.md#submission-qualifiers)
+[Development Work Flow - Submission Qualifiers](./Development-Workflow.md#submission-qualifiers)
 and
-[Development Work Flow - Submission Disqualifiers](./Development Workflow.md#submission-disqualifiers).
+[Development Work Flow - Submission Disqualifiers](./Development-Workflow.md#submission-disqualifiers).
 
 If your change gets a negative review, you will need to address the
 comments and resubmit your change.

--- a/Install-Guide/Overview.md
+++ b/Install-Guide/Overview.md
@@ -15,7 +15,7 @@ done easily in a few hours, depending on how much testing you want to
 do.
 
 After you deploy Gluster by following these steps, we recommend that
-you read the [Gluster Admin Guide](../Administrator Guide/README.md) to learn how to administer Gluster and
+you read the [Gluster Admin Guide](../Administrator Guide/) to learn how to administer Gluster and
 how to select a volume type that fits your needs. Also, be sure to
 enlist the help of the Gluster community via the IRC channel or Q&A
 section . We want you to be successful in as short a time as possible.

--- a/release-notes/3.5.1.md
+++ b/release-notes/3.5.1.md
@@ -91,7 +91,7 @@ additions:
        service glusterd restart
        ~~~
 
-   More details are also documented in the Gluster Wiki on the [Libgfapi with qemu libvirt](../Feature Planning/GlusterFS 3.5/libgfapi with qemu libvirt.md) page.
+   More details are also documented in the Gluster Wiki on the [Libgfapi with qemu libvirt](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.5/libgfapi%20with%20qemu%20libvirt.md) page.
 
 - For Block Device translator based volumes open-behind translator at the client side needs to be disabled.
 
@@ -103,6 +103,6 @@ additions:
 
 - After enabling `server.manage-gids`, the volume needs to be stopped and
   started again to have the option enabled in the brick processes
-  
+
           gluster volume stop <volname>
           gluster volume start <volname>

--- a/release-notes/3.5.2.md
+++ b/release-notes/3.5.2.md
@@ -52,7 +52,7 @@ This is mostly a bugfix release. The [Release Notes for 3.5.0](./3.5.0.md) and [
        service glusterd restart
        ~~~
 
-   More details are also documented in the Gluster Wiki on the [Libgfapi with qemu libvirt](../Feature Planning/GlusterFS 3.5/libgfapi with qemu libvirt.md) page.
+   More details are also documented in the Gluster Wiki on the [Libgfapi with qemu libvirt](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.5/libgfapi%20with%20qemu%20libvirt.md) page.
 
 - For Block Device translator based volumes open-behind translator at the
   client side needs to be disabled.

--- a/release-notes/3.5.3.md
+++ b/release-notes/3.5.3.md
@@ -64,7 +64,7 @@ features that were added and bugs fixed in the GlusterFS 3.5 stable release.
        service glusterd restart
        ~~~
 
-   More details are also documented in the Gluster Wiki on the [Libgfapi with qemu libvirt](../Feature Planning/GlusterFS 3.5/libgfapi with qemu libvirt.md) page.
+   More details are also documented in the Gluster Wiki on the [Libgfapi with qemu libvirt](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.5/libgfapi%20with%20qemu%20libvirt.md) page.
 
 - For Block Device translator based volumes open-behind translator at the
   client side needs to be disabled.

--- a/release-notes/3.5.4.md
+++ b/release-notes/3.5.4.md
@@ -58,7 +58,7 @@ release.
        service glusterd restart
        ~~~
 
-   More details are also documented in the Gluster Wiki on the [Libgfapi with qemu libvirt](../Feature Planning/GlusterFS 3.5/libgfapi with qemu libvirt.md) page.
+   More details are also documented in the Gluster Wiki on the [Libgfapi with qemu libvirt](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.5/libgfapi%20with%20qemu%20libvirt.md) page.
 
 - For Block Device translator based volumes open-behind translator at the
   client side needs to be disabled.

--- a/release-notes/3.7.0.md
+++ b/release-notes/3.7.0.md
@@ -1,4 +1,4 @@
-Release Notes for GlusterFS 3.7.0 
+Release Notes for GlusterFS 3.7.0
 
 ## Major Changes and Features
 
@@ -11,7 +11,7 @@ Many improvements have gone in the geo replication. A detailed documentation abo
 ### Bitrot Detection
 
 Bitrot detection is a technique used to identify an “insidious” type of disk error where data is silently corrupted with no indication from the disk to the
-storage software layer that an error has occurred. When bitrot detection is enabled on a volume, gluster performs signing of all files/objects in the volume and scrubs data periodically for signature verification. All anomalies observed will be noted in log files. 
+storage software layer that an error has occurred. When bitrot detection is enabled on a volume, gluster performs signing of all files/objects in the volume and scrubs data periodically for signature verification. All anomalies observed will be noted in log files.
 
 For more information, refer [here](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.7/BitRot.md).
 
@@ -51,7 +51,7 @@ Gluster 3.7 adds pro-active self healing support for erasure coded volumes.
 
 ### Exports and Netgroups Authentication for NFS
 
-This feature adds Linux-style exports & netgroups authentication to the native NFS server. This enables administrators to restrict access to specific clients & netgroups for volume/sub-directory NFSv3 exports. 
+This feature adds Linux-style exports & netgroups authentication to the native NFS server. This enables administrators to restrict access to specific clients & netgroups for volume/sub-directory NFSv3 exports.
 
 For more information refer [here](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.7/Exports%20and%20Netgroups%20Authentication.md).
 
@@ -85,7 +85,7 @@ For more information refer the below links:
 - [pNFS support for Gluster](https://github.com/gluster/glusterfs-specs/blob/master/done/Features/mount_gluster_volume_using_pnfs.md)
 
 pNFS support for Gluster volumes and NFSv4 delegations are in beta for this release. Infrastructure changes to support Lease locks and NFSv4 delegations are targeted for a 3.7.x minor release.
- 
+
 ### Snapshot Scheduling
 
 With this enhancement, administrators can schedule volume snapshots.
@@ -94,13 +94,13 @@ For more information, see [here](https://github.com/gluster/glusterfs-specs/blob
 
 ### Snapshot Cloning
 
-Volume snapshots can now be cloned to create a new writeable volume. 
+Volume snapshots can now be cloned to create a new writeable volume.
 
 For more information, see [here](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.7/Clone%20of%20Snapshot.md).
 
 ### Sharding [Experimental]
 
-Sharding addresses the problem of fragmentation of space within a volume. This feature adds support for files that are larger than the size of an individual brick. Sharding works by chunking files to blobs of a configurabe size. 
+Sharding addresses the problem of fragmentation of space within a volume. This feature adds support for files that are larger than the size of an individual brick. Sharding works by chunking files to blobs of a configurabe size.
 
 For more information, see [here](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.7/Sharding%20xlator.md).
 
@@ -122,10 +122,6 @@ split-brain resolutions can now be also driven by users without administrative i
 
 For more information, see the 'Resolution of split-brain from the mount point' section [here](https://github.com/gluster/glusterfs-specs/blob/master/done/Features/heal-info-and-split-brain-resolution.md).
 
-### Geo-replication improvements
-
-There have been several improvements in geo-replication for stability and performance. For more details, see [here](./geo-rep-in-3.7.md).
-
 ### Minor Improvements
 
 * Message ID based logging has been added for several translators.
@@ -146,14 +142,14 @@ There have been several improvements in geo-replication for stability and perfor
 
     Edit `/etc/glusterfs/glusterd.vol` to contain this line: `option rpc-auth-allow-insecure on`
 
-    Post 1, restarting the volume would be necessary: 
+    Post 1, restarting the volume would be necessary:
 
     ~~~
-    # gluster volume stop <volname> 
+    # gluster volume stop <volname>
     # gluster volume start <volname>
     ~~~
 
-    Post 2, restarting glusterd would be necessary: 
+    Post 2, restarting glusterd would be necessary:
 
     ~~~
     # service glusterd restart


### PR DESCRIPTION
Cleans up the links in all the documentation so that they don't lead to a dead-end at least to other parts of the documentation.