### PR TITLE
Fix self closing anchors

### DIFF
--- a/Administrator Guide/Managing Volumes.md
+++ b/Administrator Guide/Managing Volumes.md
@@ -15,7 +15,7 @@ operations, including the following:
 - [Triggering Self-Heal on Replicate](#triggering-self-heal-on-replicate)
 - [Non Uniform File Allocation(NUFA)](#non-uniform-file-allocation)
 
-<a name="tuning-options" />
+<a name="tuning-options"></a>
 ##Tuning Volume Options
 
 You can tune volume options, as needed, while the cluster is online and
@@ -99,7 +99,7 @@ You can view the changed volume options using command:
 
      # gluster volume info
 
-<a name="configuring-transport-types-for-a-volume" />
+<a name="configuring-transport-types-for-a-volume"></a>
 ##Configuring Transport Types for a Volume
 
 A volume can support one or more transport types for communication between clients and brick processes.
@@ -123,7 +123,7 @@ To change the supported transport types of a volume, follow the procedure:
 
         # mount -t glusterfs -o transport=rdma server1:/test-volume /mnt/glusterfs
 
-<a name="expanding-volumes" />
+<a name="expanding-volumes"></a>
 ##Expanding Volumes
 
 You can expand volumes, as needed, while the cluster is online and
@@ -184,7 +184,7 @@ replicated volume, increasing the capacity of the GlusterFS volume.
 
     You can use the rebalance command as described in [Rebalancing Volumes](#rebalancing-volumes)
 
-<a name="shrinking-volumes" />
+<a name="shrinking-volumes"></a>
 ##Shrinking Volumes
 
 You can shrink volumes, as needed, while the cluster is online and
@@ -258,7 +258,7 @@ set).
 
     You can use the rebalance command as described in [Rebalancing Volumes](#rebalancing-volumes)
 
-<a name="replace-brick" />
+<a name="replace-brick"></a>
 ##Replace faulty brick
 
 **Replacing a brick in *pure* distribute volume**
@@ -462,7 +462,7 @@ Steps:
             Brick Server2:/home/gfs/r2_3
             Number of entries: 0
 
-<a name="rebalancing-volumes" />
+<a name="rebalancing-volumes"></a>
 ##Rebalancing Volumes
 
 After expanding or shrinking a volume (using the add-brick and
@@ -597,7 +597,7 @@ You can stop the rebalance operation, as needed.
         617c923e-6450-4065-8e33-865e28d9428f               59   590      244       stopped
         Stopped rebalance process on volume test-volume
 
-<a name="stopping-volumes" />
+<a name="stopping-volumes"></a>
 ##Stopping Volumes
 
 1.  Stop the volume using the following command:
@@ -614,7 +614,7 @@ You can stop the rebalance operation, as needed.
 
         Stopping volume test-volume has been successful
 
-<a name="deleting-volumes" />
+<a name="deleting-volumes"></a>
 ##Deleting Volumes
 
 1.  Delete the volume using the following command:
@@ -631,7 +631,7 @@ You can stop the rebalance operation, as needed.
 
         Deleting volume test-volume has been successful
 
-<a name="triggering-self-heal-on-replicate" />
+<a name="triggering-self-heal-on-replicate"></a>
 ##Triggering Self-Heal on Replicate
 
 In replicate module, previously you had to manually trigger a self-heal
@@ -761,7 +761,7 @@ volume or only on the files which need *healing*.
         /69.txt
         ...
 
-<a name="non-uniform-file-allocation" />
+<a name="non-uniform-file-allocation"></a>
 ##Non Uniform File Allocation
 
 NUFA translator or Non Uniform File Access translator is designed for giving higher preference

--- a/Administrator Guide/Monitoring Workload.md
+++ b/Administrator Guide/Monitoring Workload.md
@@ -27,7 +27,7 @@ performing the following operations:
 -   [Displaying the I/0 Information](#displaying-io)
 -   [Stop Profiling](#stop-profiling)
 
-<a name="start-profiling" />
+<a name="start-profiling"></a>
 ###Start Profiling
 
 You must start the Profiling to view the File Operation information for
@@ -48,7 +48,7 @@ options are displayed in the Volume Info:
     diagnostics.count-fop-hits: on
     diagnostics.latency-measurement: on
 
-<a name="displaying-io" />
+<a name="displaying-io"></a>
 ###Displaying the I/0 Information
 
 You can view the I/O information of each brick by using the following command:
@@ -106,7 +106,7 @@ For example, to see the I/O information on test-volume:
 
     BytesWritten : 195571980
 
-<a name="stop-profiling" />
+<a name="stop-profiling"></a>
 ###Stop Profiling
 
 You can stop profiling the volume, if you do not need profiling
@@ -140,7 +140,7 @@ GlusterFS Top commands:
 -   [Viewing List of Read Performance on each Brick](#read-perf)
 -   [Viewing List of Write Performance on each Brick](#write-perf)
 
-<a name="open-fd-count" />
+<a name="open-fd-count"></a>
 ###Viewing Open fd Count and Maximum fd Count
 
 You can view both current open fd count (list of files that are
@@ -199,7 +199,7 @@ displayed.
         9               /clients/client8/~dmtmp/PARADOX/
                         STUDENTS.DB
 
-<a name="file-read" />
+<a name="file-read"></a>
 ###Viewing Highest File Read Calls
 
 You can view highest read calls on each brick. If brick name is not
@@ -241,7 +241,7 @@ specified, then by default, list of 100 files will be displayed.
 
         54               /clients/client8/~dmtmp/SEED/LARGE.FIL
 
-<a name="file-write" />
+<a name="file-write"></a>
 ###Viewing Highest File Write Calls
 
 You can view list of files which has highest file write calls on each
@@ -282,7 +282,7 @@ files will be displayed.
 
         59                /clients/client3/~dmtmp/SEED/LARGE.FIL
 
-<a name="open-dir" />
+<a name="open-dir"></a>
 ###Viewing Highest Open Calls on Directories
 
 You can view list of files which has highest open calls on directories
@@ -325,7 +325,7 @@ the bricks belonging to that volume will be displayed.
 
         402               /clients/client4/~dmtmp
 
-<a name="read-dir" />
+<a name="read-dir"></a>
 ###Viewing Highest Read Calls on Directory
 
 You can view list of files which has highest directory read calls on
@@ -368,7 +368,7 @@ bricks belonging to that volume will be displayed.
 
         800                     /clients/client4/~dmtmp
 
-<a name="read-perf" />
+<a name="read-perf"></a>
 ###Viewing List of Read Performance on each Brick
 
 You can view the read throughput of files on each brick. If brick name
@@ -462,7 +462,7 @@ and measures the corresponding throughput.
         2184.00  /clients/client5/~dmtmp/WORD/       -2011-01-31
                  BASEMACH.DOC                    15:39:09.336572
                                                    
-<a name="write-perf" />
+<a name="write-perf"></a>
 ###Viewing List of Write Performance on each Brick
 
 You can view list of write throughput of files on each brick. If brick

--- a/Administrator Guide/Setting Up Clients.md
+++ b/Administrator Guide/Setting Up Clients.md
@@ -197,7 +197,7 @@ volumes to access data. There are two methods you can choose:
 > in the client machine. You can use appropriate /etc/hosts entries or
 > DNS server to resolve server names to IP addresses.
 
-<a name="manual-mount" />
+<a name="manual-mount"></a>
 ### Manually Mounting Volumes
 
 -   To mount a volume, use the following command:
@@ -258,7 +258,7 @@ round-robin DNS is configured for the server-name..
 If `use-readdirp` is set to ON, it forces the use of readdirp
 mode in fuse kernel module
 
-<a name="auto-mount" />
+<a name="auto-mount"></a>
 ### Automatically Mounting Volumes
 
 You can configure your system to automatically mount the Gluster volume
@@ -363,7 +363,7 @@ You can use either of the following methods to mount Gluster volumes:
 
 `$ sudo aptitude install nfs-common `
 
-<a name="manual-nfs" />
+<a name="manual-nfs"></a>
 ### Manually Mounting Volumes Using NFS
 
 **To manually mount a Gluster volume using NFS**
@@ -404,7 +404,7 @@ You can use either of the following methods to mount Gluster volumes:
 
     ` # mount -o proto=tcp,vers=3 nfs://server1:38467/test-volume /mnt/glusterfs`
 
-<a name="auto-nfs" />
+<a name="auto-nfs"></a>
 ### Automatically Mounting Volumes Using NFS
 
 You can configure your system to automatically mount Gluster volumes
@@ -506,7 +506,7 @@ You can use either of the following methods to mount Gluster volumes:
 You can also use Samba for exporting Gluster Volumes through CIFS
 protocol.
 
-<a name="export-samba" />
+<a name="export-samba"></a>
 ### Exporting Gluster Volumes Through Samba
 
 We recommend you to use Samba for exporting Gluster volumes through the
@@ -543,7 +543,7 @@ scripts (/etc/init.d/smb [re]start).
 > repeat these steps on each Gluster node. For more advanced
 > configurations, see Samba documentation.
 
-<a name="cifs-manual" />
+<a name="cifs-manual"></a>
 ### Manually Mounting Volumes Using CIFS
 
 You can manually mount Gluster volumes using CIFS on Microsoft
@@ -566,7 +566,7 @@ The network drive (mapped to the volume) appears in the Computer window.
 Alternatively, to manually mount a Gluster volume using CIFS by going to 
 **Start \> Run** and entering Network path manually.
 
-<a name="cifs-auto" />
+<a name="cifs-auto"></a>
 ### Automatically Mounting Volumes Using CIFS
 
 You can configure your system to automatically mount Gluster volumes

--- a/Administrator Guide/Start Stop Daemon.md
+++ b/Administrator Guide/Start Stop Daemon.md
@@ -14,7 +14,7 @@ following ways:
 
 > **Note**: You must start glusterd on all GlusterFS servers.
 
-<a name="manual" />
+<a name="manual"></a>
 ##Starting and Stopping glusterd Manually
 
 This section describes how to start and stop glusterd manually
@@ -27,7 +27,7 @@ This section describes how to start and stop glusterd manually
 
     `# /etc/init.d/glusterd stop`
 
-<a name="auto" />
+<a name="auto"></a>
 ##Starting glusterd Automatically
 
 This section describes how to configure the system to automatically

--- a/Administrator Guide/Troubleshooting.md
+++ b/Administrator Guide/Troubleshooting.md
@@ -11,7 +11,7 @@ troubleshooting scenarios related to GlusterFS.
 * [Troubleshooting NFS](#nfs)
 * [Troubleshooting File Locks](#file-locks)
 
-<a name="logs" />
+<a name="logs"></a>
 ##Managing GlusterFS Logs
 
 ###Rotating Logs
@@ -31,7 +31,7 @@ For example, to rotate the log file on test-volume:
 > When a log file is rotated, the contents of the current log file
 > are moved to log-file- name.epoch-time-stamp.
 
-<a name="georep" />
+<a name="georep"></a>
 ##Troubleshooting Geo-replication
 
 This section describes the most common troubleshooting scenarios related
@@ -196,7 +196,7 @@ geo-replication module has detected change in primary master. If this is
 the desired behavior, delete the config option volume-id in the session
 initiated from the intermediate master.
 
-<a name="posix-acls" />
+<a name="posix-acls"></a>
 ##Troubleshooting POSIX ACLs
 
 This section describes the most common troubleshooting issues related to
@@ -211,7 +211,7 @@ server "Posix access control list is not supported".
 
 **Solution**: Remount the backend file system with "-o acl" option.
 
-<a name="hadoop" />
+<a name="hadoop"></a>
 ##Troubleshooting Hadoop Compatible Storage
 
 ###Time Sync
@@ -221,7 +221,7 @@ the hosts in the cluster.
 
 **Solution**: Sync the time on all hosts using ntpd program.
 
-<a name="nfs" />
+<a name="nfs"></a>
 ##Troubleshooting NFS
 
 This section describes the most common troubleshooting issues related to
@@ -412,7 +412,7 @@ using the following flag with gcc:
 
 ` -D_FILE_OFFSET_BITS=64`
 
-<a name="file-locks" />
+<a name="file-locks"></a>
 ##Troubleshooting File Locks
 
 In GlusterFS 3.3 you can use `statedump` command to list the locks held


### PR DESCRIPTION
fixes `<a name="title" />` to `<a name="title"></a>` so Chrome doesn't wrap the entire content in an `a` tag removing text styles.

For example, http://gluster.readthedocs.io/en/latest/Administrator%20Guide/Managing%20Volumes/ is very blue for this reason.