### PR TITLE
Fixed issue with detection of Debian version

### DIFF
--- a/Install-Guide/Install.md
+++ b/Install-Guide/Install.md
@@ -13,8 +13,9 @@ Add the GPG key to apt:
 
 Add the source:
 
-    DEBVER=$(grep 'VERSION_ID' /etc/os-release | cut -d '=' -f 2 | tr -d '"')
-    echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBVER}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list 
+    DEBID=$(grep 'VERSION_ID=' /etc/os-release | cut -d '=' -f 2 | tr -d '"')
+    DEBVER=$(grep 'VERSION=' /etc/os-release | grep -Eo '[a-z]+')
+    echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list 
 
 Update package list:
 

--- a/Install-Guide/Install.md
+++ b/Install-Guide/Install.md
@@ -13,7 +13,7 @@ Add the GPG key to apt:
 
 Add the source:
 
-    DEBVER=$(grep 'VERSION_ID' /etc/os-release | cut -d '=' -f 2 | tr -d '"');
+    DEBVER=$(grep 'VERSION_ID' /etc/os-release | cut -d '=' -f 2 | tr -d '"')
     echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBVER}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list 
 
 Update package list:

--- a/Install-Guide/Install.md
+++ b/Install-Guide/Install.md
@@ -13,7 +13,7 @@ Add the GPG key to apt:
 
 Add the source:
 
-    DEBVER=$(awk '/^VERSION=/{print gensub(/.*[(](.*)[)].*/,"\\1",1)}' /etc/os-release)
+    DEBVER=$(grep 'VERSION_ID' /etc/os-release | cut -d '=' -f 2 | tr -d '"');
     echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBVER}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list 
 
 Update package list:


### PR DESCRIPTION
The old awk command fails, due gensub was never defined:

```
root@glusterfs01:~# awk '/^VERSION=/{print gensub(/.*[(](.*)[)].*/,"\\1",1)}' /etc/os-release
awk: line 2: function gensub never defined
```