### PR TITLE
Add -p argument to create along with parent directories.

### DIFF
--- a/Quick-Start-Guide/Quickstart.md
+++ b/Quick-Start-Guide/Quickstart.md
@@ -92,7 +92,7 @@ must be probed from the pool.
 
 On both server1 and server2:
 
-		mkdir /data/brick1/gv0
+		mkdir -p /data/brick1/gv0
 
 From any single server:
 


### PR DESCRIPTION
To create multiple directories, we need to add an argument '-p' along with
the 'mkdir' command.
So, I thought the command should be 'mkdir -p <parent-directory>/<directory>'.
@itisravi can you please review the same.
thanks.