### PR TITLE
add fuse-devel as a build requirement

### DIFF
--- a/Developer-guide/Building-GlusterFS.md
+++ b/Developer-guide/Building-GlusterFS.md
@@ -24,13 +24,14 @@ The following packages are required for building GlusterFS,
 -   cmocka
 -   libacl
 -   sqlite
+-   fuse-devel
 
 ### Fedora
 
 The following yum command installs all the build requirements for
 Fedora,
 
-		# yum install automake autoconf libtool flex bison openssl-devel libxml2-devel python-devel libaio-devel libibverbs-devel librdmacm-devel readline-devel lvm2-devel glib2-devel userspace-rcu-devel libcmocka-devel libacl-devel sqlite-devel
+		# yum install automake autoconf libtool flex bison openssl-devel libxml2-devel python-devel libaio-devel libibverbs-devel librdmacm-devel readline-devel lvm2-devel glib2-devel userspace-rcu-devel libcmocka-devel libacl-devel sqlite-devel fuse-devel
 
 ### Ubuntu
 


### PR DESCRIPTION
Adding fuse-devel as a build requirement. 
Otherwise, Gluster build fails saying fuse-devel required.

Observed in centos-7