### PR TITLE
Fixed the syntax for installing mkdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ mkdocs, with the following command (replace yum by dnf on Fedora):
 
     # yum install mkdocs
 
+Install mkdocs in Fedora 23+
+    
+    #pip install --upgrade pip
+    #python get-pip.py
+    #pip install mkdocs
+
 Then you need to run mkdocs from the root of that repository:
 
     $ mkdocs build


### PR DESCRIPTION
As mkdocs is not getting installed in fedora from DNF .