### PR TITLE
Remove spaces from netgroup ip's

### DIFF
--- a/Administrator Guide/Export And Netgroup Authentication.md
+++ b/Administrator Guide/Export And Netgroup Authentication.md
@@ -14,7 +14,7 @@ Here export name can be gluster volume or subdirectory path inside that volume. 
 
 The file `/var/lib/glusterd/nfs/netgroup` should mention the expansion of each netgroup which mentioned  in the export file. An typical netgroup entry will look like :
 
-        <netgroup name> ng1000\nng1000 ng999\nng999 ng1\nng1 ng2\nng2 (ip1, ip2,..)
+        <netgroup name> ng1000\nng1000 ng999\nng999 ng1\nng1 ng2\nng2 (ip1,ip2,..)
 
 The gluster NFS server will check the contents of these file after specific time intervals
 


### PR DESCRIPTION
glusterfsd prints out a warning message if the ip addresses contain and space between them.
```
[2017-02-15 22:03:14.216633] W [netgroups.c:824:_ng_handle_host_part] 0-nfs-netgroup: Parse error for: (192.168.1.1,
```
I removed the space so if people are copy and pasting from the docs they won't encounter this.