### PR TITLE
Docs cleanup

### DIFF
--- a/Administrator Guide/GlusterFS Introduction.md
+++ b/Administrator Guide/GlusterFS Introduction.md
@@ -37,9 +37,9 @@ healthcare, government, education, web 2.0, and financial services.
 
 ## Commercial offerings and support ##
 
-Several companies offer support or consulting - http://www.gluster.org/consultants/.
+Several companies offer support or [consulting](http://www.gluster.org/consultants/).
 
-Red Hat Storage (http://www.redhat.com/en/technologies/storage/storage-server)
+[Red Hat Storage](http://www.redhat.com/en/technologies/storage/storage-server)
 is a commercial storage software product, based on GlusterFS.
 
 

--- a/Contributors-Guide/Adding-your-blog.md
+++ b/Contributors-Guide/Adding-your-blog.md
@@ -2,11 +2,10 @@
 
 As a developer/user, you have blogged about gluster and want to share the post to Gluster community.
 
-OK, you can do that by editing this file.
-https://github.com/gluster/planet-gluster/blob/master/data/feeds.yml
+OK, you can do that by editing planet-gluster [feeds](https://github.com/gluster/planet-gluster/blob/master/data/feeds.yml) on github.
 
 Please find instructions mentioned in the file and send a pull request.
 
-Once approved, all your gluster related posts will appear in planet.gluster.org
+Once approved, all your gluster related posts will appear in [planet.gluster.org](http://planet.gluster.org) wbesite.
 
 

--- a/Contributors-Guide/Bug-Reporting-Guidelines.md
+++ b/Contributors-Guide/Bug-Reporting-Guidelines.md
@@ -70,7 +70,7 @@ You should gather the information below before creating the bug report.
 -   Output of `gluster volume status`
 -   Get the statedump of the volume with the problem
 
-`   $ gluster volume statedump `<vol-name>
+`   $ gluster volume statedump <vol-name>`
 
 This dumps statedump per brick process in `/var/run/gluster`
 
@@ -96,7 +96,7 @@ collected directories could be archived,compressed and attached to bug
 -   OS Type ( Windows, RHEL )
 -   OS Version : In case of Linux distro get the following :
 
-`   $ uname -r`\
+`   $ uname -r`
 `   $ cat /etc/issue`
 
 -   Fuse or NFS Mount point on the client with output of mount commands

--- a/Contributors-Guide/GlusterFS-Release-process.md
+++ b/Contributors-Guide/GlusterFS-Release-process.md
@@ -24,8 +24,8 @@ STM releases are only supported until the next major release. STM releases may g
 
 The discussions around release schedules and lifecycles happened in the following mail threads on the GlusterFS maintainers mailing list.
 
-- https://www.gluster.org/pipermail/maintainers/2016-June/000892.html
-- https://www.gluster.org/pipermail/maintainers/2016-August/001174.html
+- [2016-June/000892](https://www.gluster.org/pipermail/maintainers/2016-June/000892.html)
+- [2016-August/001174](https://www.gluster.org/pipermail/maintainers/2016-August/001174.html)
 
 
 ## GlusterFS major release window

--- a/Contributors-Guide/GlusterFS-Release-process.md
+++ b/Contributors-Guide/GlusterFS-Release-process.md
@@ -50,7 +50,7 @@ All changes will be accepted during the Open phase. The changes have a few requi
 #### Stability phase
 This phase is used to stabilize any new features introduced in the open phase, or general bug fixes for already existing features.
 
-A new release-<version> branch is created at the beginning of this phase. All changes need to be sent to the master branch before getting backported to the new release branch.
+A new `release-<version>` branch is created at the beginning of this phase. All changes need to be sent to the master branch before getting backported to the new release branch.
 
 No new features will be merged in this phase. At the end of this phase, any new feature introduced that hasn't been declared stable will be disabled, if possible removed, to prevent confusion and set clear expectations towards users and developers.
 

--- a/Contributors-Guide/Index.md
+++ b/Contributors-Guide/Index.md
@@ -30,5 +30,5 @@ Blogging about gluster
 ----------------
 
 -   The [Adding your gluster blog](./Adding-your-blog.md) explains how to add your
-gluster blog to Community blogger. 
- 
+gluster blog to Community blogger.
+

--- a/Install-Guide/Common_criteria.md
+++ b/Install-Guide/Common_criteria.md
@@ -7,6 +7,7 @@ To start, we will go over some common things you will need to know for
 setting up Gluster.
 
 Next, choose the method you want to use to set up your first cluster:
+
 -  Within a virtual machine
 -  To bare metal servers
 -  To EC2 instances in Amazon

--- a/Install-Guide/Community_Packages.md
+++ b/Install-Guide/Community_Packages.md
@@ -1,9 +1,9 @@
 ### Community Packages
 
-An **X** means packages are planned to be in the respective repository.  
-A **—** means we have no plans to build the version for the repository.  
-**d.g.o** means packages will (also) be provided on https://download.gluster.org  
-**DNF/YUM** means the packages are included in the Fedora Updates or Updates-testing repos.  
+An **X** means packages are planned to be in the respective repository.
+A **—** means we have no plans to build the version for the repository.
+**d.g.o** means packages will (also) be provided on [download section](https://download.gluster.org)
+**DNF/YUM** means the packages are included in the Fedora Updates or Updates-testing repos.
 
 |              |             | 3.10 ltm | 3.9 stm⁴ | 3.8 ltm  | 3.7 eol⁴ |
 |--------------|-------------|:--------:|:--------:|:--------:|:--------:|
@@ -29,7 +29,7 @@ A **—** means we have no plans to build the version for the repository.
 |              |SLES11       |    —     |    —     |    —     |    —     |
 |              |SLES12       |    X     |    X     |    X     |    X     |
 
-¹ https://wiki.centos.org/SpecialInterestGroup/Storage  
-² https://launchpad.net/~gluster  
-³ https://build.opensuse.org/project/subprojects/home:kkeithleatredhat  
+¹ https://wiki.centos.org/SpecialInterestGroup/Storage
+² https://launchpad.net/~gluster
+³ https://build.opensuse.org/project/subprojects/home:kkeithleatredhat
 ⁴ support ends at 3.10 GA

--- a/Install-Guide/Configure.md
+++ b/Install-Guide/Configure.md
@@ -11,17 +11,21 @@ Remember that the trusted pool is the term used to define a cluster of
 nodes in Gluster. Choose a server to be your “primary” server. This is
 just to keep things simple, you will generally want to run all commands
 from this tutorial. Keep in mind, running many Gluster specific commands
-(like \`gluster volume create\`) on one server in the cluster will
+(like `gluster volume create`) on one server in the cluster will
 execute the same command on all other servers.
 
-		gluster peer probe (hostname of the other server in the cluster, or IP address if you don’t have DNS or /etc/hosts entries)
+Replace `nodename` with hostname of the other server in the cluster,
+or IP address if you don’t have DNS or `/etc/hosts` entries.
+Let say we want to connect to `node01`:
 
-Notice that running \`gluster peer status\` from the second node shows
+		gluster peer probe node01
+
+Notice that running `gluster peer status` from the second node shows
 that the first node has already been added.
 
 ### Partition the disk
 
-Assuming you have a empty disk at /dev/sdb:
+Assuming you have a empty disk at `/dev/sdb`:
 
 		fdisk /dev/sdb 
 
@@ -49,20 +53,26 @@ files, on average, fifty will end up on one server, and fifty will end
 up on another. This is faster than a “replicated” volume, but isn’t as
 popular since it doesn’t give you two of the most sought after features
 of Gluster — multiple copies of the data, and automatic failover if
-something goes wrong. To set up a replicated volume:
+something goes wrong.
+
+To set up a replicated volume:
 
 		gluster volume create gv0 replica 2 node01.mydomain.net:/export/sdb1/brick node02.mydomain.net:/export/sdb1/brick
 
-Breaking this down into pieces, the first part says to create a gluster
-volume named gv0 (the name is arbitrary, gv0 was chosen simply because
-it’s less typing than gluster\_volume\_0). Next, we tell it to make the
-volume a replica volume, and to keep a copy of the data on at least 2
-bricks at any given time. Since we only have two bricks total, this
-means each server will house a copy of the data. Lastly, we specify
-which nodes to use, and which bricks on those nodes. The order here is
-important when you have more bricks…it is possible (as of the most
-current release as of this writing, Gluster 3.3) to specify the bricks
-in a such a way that you would make both copies of the data reside on a
+Breaking this down into pieces:
+
+- the first part says to create a gluster volume named gv0
+(the name is arbitrary, gv0 was chosen simply because
+it’s less typing than gluster\_volume\_0).
+- make the volume a replica volume
+- keep a copy of the data on at least 2 bricks at any given time.
+Since we only have two bricks total, this
+means each server will house a copy of the data.
+- we specify which nodes to use, and which bricks on those nodes. The order here is
+important when you have more bricks.
+
+It is possible (as of the most current release as of this writing, Gluster 3.3)
+to specify the bricks in a such a way that you would make both copies of the data reside on a
 single node. This would make for an embarrassing explanation to your
 boss when your bulletproof, completely redundant, always on super
 cluster comes to a grinding halt when a single point of failure occurs.
@@ -84,7 +94,7 @@ And you should see results similar to the following:
 	    Brick2: node02.yourdomain.net:/export/sdb1/brick
 
 This shows us essentially what we just specified during the volume
-creation. The one this to mention is the “Status”. A status of “Created”
+creation. The one this to mention is the `Status`. A status of `Created`
 means that the volume has been created, but hasn’t yet been started,
 which would cause any attempt to mount the volume fail.
 

--- a/Install-Guide/Configure.md
+++ b/Install-Guide/Configure.md
@@ -16,9 +16,9 @@ execute the same command on all other servers.
 
 Replace `nodename` with hostname of the other server in the cluster,
 or IP address if you don’t have DNS or `/etc/hosts` entries.
-Let say we want to connect to `node01`:
+Let say we want to connect to `node02`:
 
-		gluster peer probe node01
+		gluster peer probe node02
 
 Notice that running `gluster peer status` from the second node shows
 that the first node has already been added.

--- a/Install-Guide/Install.md
+++ b/Install-Guide/Install.md
@@ -19,7 +19,7 @@ Add the source:
 
     DEBID=$(grep 'VERSION_ID=' /etc/os-release | cut -d '=' -f 2 | tr -d '"')
     DEBVER=$(grep 'VERSION=' /etc/os-release | grep -Eo '[a-z]+')
-    echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list 
+    echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list
 
 Update package list:
 
@@ -35,7 +35,7 @@ Install:
 Ubuntu 10 and 12: install python-software-properties:
 
 		sudo apt-get install python-software-properties
-		
+
 Ubuntu 14: install software-properties-common:
 
 		sudo apt-get install software-properties-common

--- a/Install-Guide/Overview.md
+++ b/Install-Guide/Overview.md
@@ -86,7 +86,11 @@ restore the database would be fine - Gluster is traditionally better
 when using file sizes at of least 16KB (with a sweet spot around 128KB
 or so).
 
-#### How many billions of dollars is it going to cost to setup a cluster? Don’t I need redundant networking, super fast SSD’s, technology from Alpha Centauri delivered by men in black, etc…?
+#### What is the cost and complexity required to set up cluster?
+
+Question: How many billions of dollars is it going to cost to setup a cluster?
+Don’t I need redundant networking, super fast SSD’s,
+technology from Alpha Centauri delivered by men in black, etc…?
 
 I have never seen anyone spend even close to a billion, unless they got
 the rust proof coating on the servers. You don’t seem like the type that

--- a/Quick-Start-Guide/Terminologies.md
+++ b/Quick-Start-Guide/Terminologies.md
@@ -92,9 +92,9 @@ management operations happen on the volume.
 
 ### Vol file
 
-.vol files are configuration files used by glusterfs process. Volfiles
-will be usually located at /var/lib/glusterd/vols/volume-name/.
-Eg:vol-name-fuse.vol,export-brick-name.vol,etc.. Sub-volumes in the .vol
+`.vol` files are configuration files used by glusterfs process. Volfiles
+will be usually located at `/var/lib/glusterd/vols/volume-name/`.
+Eg: `vol-name-fuse.vol`, `export-brick-name.vol` etc. Sub-volumes in the `.vol`
 files are present in the bottom-up approach and then after tracing forms
 a tree structure, where in the hierarchy last comes the client volumes.
 

--- a/index.md
+++ b/index.md
@@ -1,15 +1,15 @@
 # GlusterFS Documentation
 
 GlusterFS is a scalable network filesystem
-suitable for data-intensive tasks such as cloud storage and media streaming. 
-GlusterFS is free and open source software and can utilize common off-the-shelf 
+suitable for data-intensive tasks such as cloud storage and media streaming.
+GlusterFS is free and open source software and can utilize common off-the-shelf
 hardware. To learn more, [please see the Gluster project home page](http://www.gluster.org).
 
-**Get Started: Quick Start/Installation Guide**  
+**Get Started: Quick Start/Installation Guide**
 
-Since Gluster can be used in different ways and for different tasks, it would be difficult 
-to explain everything at once. We recommend that you follow the Quick Start Guide first. By 
-utilizing a number of virtual machines, you will create a functional test setup to learn the 
+Since Gluster can be used in different ways and for different tasks, it would be difficult
+to explain everything at once. We recommend that you follow the Quick Start Guide first. By
+utilizing a number of virtual machines, you will create a functional test setup to learn the
 basic concepts. You will then be much better equipped to read the more detailed
 Install Guide.
 
@@ -19,11 +19,11 @@ Install Guide.
 
 -  [Presentations](./presentations/index.md) related to Gluster from Conferences and summits.
 
-**More Documentation**  
+**More Documentation**
 
 -  [Administration Guide](./Administrator Guide/index.md) - describes the configuration and management of GlusterFS.
 
--  [GlusterFS Developer Guide](./Developer-guide/Developers-Index.md) - describes how you can contribute to this open source project; built through the efforts of its dedicated, passionate community. 
+-  [GlusterFS Developer Guide](./Developer-guide/Developers-Index.md) - describes how you can contribute to this open source project; built through the efforts of its dedicated, passionate community.
 
 -  [Upgrade Guide](./Upgrade-Guide/README.md) - if you need to upgrade from an older version of GlusterFS.
 
@@ -35,12 +35,12 @@ Install Guide.
 
 **How to Contribute?**
 
-The Gluster documentation has its home on GitHub, and the easiest way to contribute is to use 
+The Gluster documentation has its home on GitHub, and the easiest way to contribute is to use
 the "Edit on GitHub" link on the top right corner of each page. If you already have a GitHub
 account, you can simply edit the document in your browser, use the preview tab, and submit
 your changes for review in a pull request.
 
-If you want to help more with Gluster documentation, please subscribe to [Gluster 
-Users](http://www.gluster.org/mailman/listinfo/gluster-users) and [Gluster 
+If you want to help more with Gluster documentation, please subscribe to [Gluster
+Users](http://www.gluster.org/mailman/listinfo/gluster-users) and [Gluster
 Developers](http://www.gluster.org/mailman/listinfo/gluster-devel) mailing lists,
 and share your ideas with the Gluster developer community.


### PR DESCRIPTION
Major changes:
- shorten certain long titles to shorter ones,
- make some section more simple in understanding.

Minor cleanups:
- remove obsolete trailing spaces,
- formatting fixes for code/script blocks,
- convert links to clickable URLs.
