### PR TITLE
Update documentation on op-version

### DIFF
--- a/Upgrade-Guide/op_version.md
+++ b/Upgrade-Guide/op_version.md
@@ -12,9 +12,11 @@ Current op-version can be queried as below:
 
     [root@~]#gluster volume get all cluster.op-version
 
-To check maximum op-version supported by the cluster, the following query can be used:
+To get the maximum possible op-version a cluster can support, the following query can be used:
 
     [root@~]#gluster volume get all cluster.max-op-version
+
+For example, if some nodes in a cluster have been upgraded to X and some to X+, then the maximum op-version supported by the cluster is X, and the cluster.op-version can be bumped up to X to support new features.
 
 op-version can be updated as below.
 For example, after upgrading to glusterfs-3.7.1, set op-version as:
@@ -26,7 +28,13 @@ This is not mandatory, but advisable to have updated op-version if you want to m
 
 ###Client op-version
 
-To check op-version information for clients the following query can be used:
+When trying to set a volume option, it might happen that one or more of the connected clients cannot support the feature being set and might need to be upgraded to the op-version the cluster is currently running on.
+
+To check op-version information for the connected clients and find the offending client, the following query can be used:
 
     [root@~]#gluster volume status <all|VOLNAME> clients
+
+The respective clients can then be upgraded to the required version.
+
+This information could also be used to make an informed decision while bumping up the op-version of a cluster, so that connected clients can support all the new features provided by the upgraded cluster as well.
 

--- a/Upgrade-Guide/op_version.md
+++ b/Upgrade-Guide/op_version.md
@@ -10,7 +10,11 @@ After Gluster upgrade, it is advisable to have op-version updated.
 
 Current op-version can be queried as below:
 
-    [root@~]#gluster volume get  <volume name> cluster.op-version
+    [root@~]#gluster volume get all cluster.op-version
+
+To check maximum op-version supported by the cluster, the following query can be used:
+
+    [root@~]#gluster volume get all cluster.max-op-version
 
 op-version can be updated as below.
 For example, after upgrading to glusterfs-3.7.1, set op-version as:
@@ -19,4 +23,10 @@ For example, after upgrading to glusterfs-3.7.1, set op-version as:
 
 Note: 
 This is not mandatory, but advisable to have updated op-version if you want to make use of latest features in the updated gluster.
+
+###Client op-version
+
+To check op-version information for clients the following query can be used:
+
+    [root@~]#gluster volume status <all|VOLNAME> clients
 


### PR DESCRIPTION
Update op-version related documentation to include information on
the following:
 - How to get maximum supported op-version in a cluster
 - How to get op-version information for clients

Also updated the usage wrt getting current op-version to reflect
the new usage format to query global options using volume get all.