### PR TITLE
Added 3.10 upgrade guide

### DIFF
--- a/Upgrade-Guide/README.md
+++ b/Upgrade-Guide/README.md
@@ -7,4 +7,5 @@ If you are using GlusterFS version 3.4.x or below, you ca upgrade it to followin
 -   [Upgrading to 3.6](./upgrade_to_3.6.md)
 -   [Upgrading to 3.7](./upgrade_to_3.7.md)
 -   [Upgrading to 3.9](./upgrade_to_3.9.md)
+-   [Upgrading to 3.10](./upgrade_to_3.10.md)
 -   [About op-version](./op_version.md)

--- a/Upgrade-Guide/README.md
+++ b/Upgrade-Guide/README.md
@@ -1,11 +1,11 @@
 Upgrading GlusterFS
 -------------------
+-   [About op-version](./op_version.md)
 
-If you are using GlusterFS version 3.4.x or below, you ca upgrade it to following: 
+If you are using GlusterFS version 3.4.x or below, you can upgrade it to following: 
 
 -   [Upgrading to 3.5](./upgrade_to_3.5.md)
 -   [Upgrading to 3.6](./upgrade_to_3.6.md)
 -   [Upgrading to 3.7](./upgrade_to_3.7.md)
 -   [Upgrading to 3.9](./upgrade_to_3.9.md)
 -   [Upgrading to 3.10](./upgrade_to_3.10.md)
--   [About op-version](./op_version.md)

--- a/Upgrade-Guide/upgrade_to_3.10.md
+++ b/Upgrade-Guide/upgrade_to_3.10.md
@@ -1,0 +1,94 @@
+## Upgrade procedure to Gluster 3.10.0, from Gluster 3.9.x, 3.8.x and 3.7.x
+
+### Pre-upgrade notes 
+- Online upgrade is only possible with replicated and distributed replicate volumes
+- Online upgrade is not supported for dispersed or distributed dispersed volumes
+- Ensure no configuration changes are done during the upgrade
+- If you are using geo-replication, please upgrade the slave cluster(s) before upgrading the master
+- Upgrading the servers ahead of the clients is recommended
+- It is recommended to have the same client and server, major versions running eventually
+
+### Online upgrade procedure for servers
+This procedure involves upgrading **one server at a time**, while keeping the volume(s) online and client IO ongoing. This procedure assumes that multiple replicas of a replica set, are not part of the same server in the trusted storage pool.
+
+> **ALERT**: If any of your volumes, in the trusted storage pool that is being upgraded, uses disperse or is a pure distributed volume, this procedure is **NOT** recommended, use the [Offline upgrade procedure](#offline-upgrade-procedure) instead.
+
+#### Repeat the following steps, on each server in the trusted storage pool, to upgrade the entire pool to 3.10 version:
+1. Stop all gluster services, either using the command below, or through other means,
+    ```bash
+    #killall glusterfs glusterfsd glusterd
+    ```
+
+2. Stop all applications that run on this server and access the volumes via gfapi (qemu, NFS-Ganesha, Samba, etc.)
+
+3. Install Gluster 3.10
+
+4. Ensure that version reflects 3.10.0 in the output of,
+    ```bash
+    #gluster --version
+    ```
+
+5. Start glusterd on the upgraded server
+    ```bash
+    #glusterd
+    ```
+
+6. Ensure that all gluster processes are online by checking the output of,
+    ```bash
+    #gluster volume status
+    ```
+
+7. Self-heal all gluster volumes by running
+    ```bash
+    #for i in `gluster volume list`; do gluster volume heal $i; done
+    ```
+
+8. Ensure that there is no heal backlog by running the below command for all volumes
+    ```bash
+    #gluster volume heal <volname> info
+    ```
+> NOTE: If there is a heal backlog, wait till the backlog is empty, or the backlog does not have any entries needing a sync to the just upgraded server, before proceeding to upgrade the next server in the pool
+
+9. Restart any gfapi based application stopped previously in step (2)
+
+### Offline upgrade procedure
+This procedure involves cluster downtime and during the upgrade window, clients are not allowed access to the volumes.
+
+#### Steps to perform an offline upgrade:
+1. On every server in the trusted storage pool, stop all gluster services, either using the command below, or through other means,
+    ```bash
+    #killall glusterfs glusterfsd glusterd
+    ```
+2. Stop all applications that access the volumes via gfapi (qemu, NFS-Ganesha, Samba, etc.), across all servers
+
+3. Install Gluster 3.10, on all servers
+
+4. Ensure that version reflects 3.10.0 in the output of the following command on all servers,
+    ```bash
+    #gluster --version
+    ```
+
+5. Start glusterd on all the upgraded servers
+    ```bash
+    #glusterd
+    ```
+6. Ensure that all gluster processes are online by checking the output of,
+    ```bash
+    #gluster volume status
+    ```
+
+7. Restart any gfapi based application stopped previously in step (2)
+
+### Post upgrade steps
+Perform the following steps post upgrading the entire trusted storage pool,
+- It is recommended to update the op-version of the cluster. Refer, to the [op-version](./op_version.md) section for further details
+- Proceed to [upgrade the clients](#upgrade-procedure-for-clients) to 3.10 version as well
+
+### Upgrade procedure for clients
+Following are the steps to upgrade clients to the 3.10.0 version,
+
+1. Unmount all glusterfs mount points on the client
+2. Stop all applications that access the volumes via gfapi (qemu, etc.)
+3. Install Gluster 3.10
+4. Mount all gluster shares
+5. Start any applications that were stopped previously in step (2)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,12 +92,13 @@ pages:
   - Index: Ops-Guide/Overview.md
   - Tools: Ops-Guide/Tools.md
 - Upgrade-Guide:
+  - Op-version: Upgrade-Guide/op_version.md
   - Upgrade-Guide Index: Upgrade-Guide/README.md
   - Upgrade to 3.5: Upgrade-Guide/upgrade_to_3.5.md
   - Upgrade to 3.6: Upgrade-Guide/upgrade_to_3.6.md
   - Upgrade to 3.7: Upgrade-Guide/upgrade_to_3.7.md
   - Upgrade to 3.9: Upgrade-Guide/upgrade_to_3.9.md
-  - Op-version: Upgrade-Guide/op_version.md
+  - Upgrade to 3.10: Upgrade-Guide/upgrade_to_3.10.md
 - Release Notes:
   - index: release-notes/index.md
   - 3.9.0: release-notes/3.9.0.md


### PR DESCRIPTION
Added 3.10 upgrade guide, based on 3.9 guide with some content and formatting changes.

Also linked the README to the 3.10 guide as a part of this commit.

This can go live before 3.10 release, as nothing should change. Also, in case there are any last minute incompatibilities, we can edit the content anyway.