### PR TITLE
Update SSL.md to fix ssl.cert-depth option name

### DIFF
--- a/Administrator Guide/SSL.md
+++ b/Administrator Guide/SSL.md
@@ -104,7 +104,7 @@ internals.
 The first option allows the user to set the certificate depth, as mentioned
 above.
 
-	gluster volume set MYVOLUME ssl.cert-depth 2
+	gluster volume set MYVOLUME ssl.certificate-depth 2
 
 Here, we're setting our certificate depth to two, as in the introductory
 example.  By default this value is zero, meaning that only certificates which


### PR DESCRIPTION
Changed ssl.cert-depth to ssl.certificate-depth partly fulfils #105
ssl.certificate-depth is defined here https://github.com/gluster/glusterfs/blob/master/xlators/mgmt/glusterd/src/glusterd-volgen.h#L51