### PR TITLE
Updated docs with release 3.10.1 release-notes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ pages:
   - Upgrade to 3.10: Upgrade-Guide/upgrade_to_3.10.md
 - Release Notes:
   - index: release-notes/index.md
+  - 3.10.1: release-notes/3.10.1.md
   - 3.10.0: release-notes/3.10.0.md
   - 3.9.0: release-notes/3.9.0.md
   - 3.7.1: release-notes/3.7.1.md

--- a/release-notes/3.10.1.md
+++ b/release-notes/3.10.1.md
@@ -1,0 +1,50 @@
+# Release notes for Gluster 3.10.1
+
+This is a bugfix release. The release notes for [3.10.0](3.10.0.md),
+contains a listing of all the new features that were added and
+bugs in the GlusterFS 3.10 stable release.
+
+## Major changes, features and limitations addressed in this release
+
+1. auth-allow setting was broken with 3.10 release and is now fixed (#1429117) 
+
+## Major issues
+
+1. Expanding a gluster volume that is sharded may cause file corruption
+    - Sharded volumes are typically used for VM images, if such volumes are
+    expanded or possibly contracted (i.e add/remove bricks and rebalance)
+    there are reports of VM images getting corrupted.
+    - If you are using sharded volumes, DO NOT rebalance them till this is
+    fixed
+    - Status of this bug can be tracked here, [#1426508](https://bugzilla.redhat.com/1426508)
+
+## Bugs addressed
+
+A total of 31 patches have been merged, addressing 26 bugs:
+
+- [#1419824](https://bugzilla.redhat.com/1419824): repeated operation failed warnings in gluster mount logs with disperse volume
+- [#1422769](https://bugzilla.redhat.com/1422769): brick process crashes when glusterd is restarted
+- [#1422781](https://bugzilla.redhat.com/1422781): Transport endpoint not connected error seen on client when glusterd is restarted
+- [#1426222](https://bugzilla.redhat.com/1426222): build: fixes to build 3.9.0rc2 on Debian (jessie)
+- [#1426323](https://bugzilla.redhat.com/1426323): common-ha: no need to remove nodes one-by-one in teardown
+- [#1426329](https://bugzilla.redhat.com/1426329): [Ganesha] : Add comment to Ganesha HA config file ,about cluster name's length limitation
+- [#1427387](https://bugzilla.redhat.com/1427387): systemic testing: seeing lot of ping time outs  which would lead to splitbrains
+- [#1427399](https://bugzilla.redhat.com/1427399): [RFE] capture portmap details in glusterd's statedump
+- [#1427461](https://bugzilla.redhat.com/1427461): Bricks take up new ports upon volume restart after add-brick op with brick mux enabled
+- [#1428670](https://bugzilla.redhat.com/1428670): Disconnects in nfs mount leads to IO hang and mount inaccessible
+- [#1428739](https://bugzilla.redhat.com/1428739): Fix crash in dht resulting from tests/features/nuke.t
+- [#1429117](https://bugzilla.redhat.com/1429117): auth failure after upgrade to GlusterFS 3.10
+- [#1429402](https://bugzilla.redhat.com/1429402): Restore atime/mtime for symlinks and other non-regular files.
+- [#1429773](https://bugzilla.redhat.com/1429773): disallow increasing replica count for arbiter volumes
+- [#1430512](https://bugzilla.redhat.com/1430512): /libgfxdr.so.0.0.1: undefined symbol: __gf_free
+- [#1430844](https://bugzilla.redhat.com/1430844): build/packaging: Debian and Ubuntu don't have /usr/libexec/; results in bad packages
+- [#1431175](https://bugzilla.redhat.com/1431175): volume start command hangs
+- [#1431176](https://bugzilla.redhat.com/1431176): USS is broken when multiplexing is on
+- [#1431591](https://bugzilla.redhat.com/1431591): memory leak in features/locks xlator
+- [#1434296](https://bugzilla.redhat.com/1434296): [Disperse] Metadata version is not healing when a brick is down
+- [#1434303](https://bugzilla.redhat.com/1434303): Move spit-brain msg in read txn to debug
+- [#1434399](https://bugzilla.redhat.com/1434399): glusterd crashes when peering an IP where the address is more than acceptable range (>255) OR with random hostnames
+- [#1435946](https://bugzilla.redhat.com/1435946): When parallel readdir is enabled and there are simultaneous readdir and disconnects, then it results in crash
+- [#1436203](https://bugzilla.redhat.com/1436203): Undo pending xattrs only on the up bricks
+- [#1436411](https://bugzilla.redhat.com/1436411): Unrecognized filesystems (i.e. btrfs, zfs) log many errors about "getinode size"
+- [#1437326](https://bugzilla.redhat.com/1437326): Sharding: Fix a performance bug

--- a/release-notes/index.md
+++ b/release-notes/index.md
@@ -3,6 +3,7 @@ Release Notes
 
 ###GlusterFS 3.10 release notes
 
+- [3.10.1](./3.10.1.md)
 - [3.10.0](./3.10.0.md)
 
 ###GlusterFS 3.9 release notes


### PR DESCRIPTION
Tested using local build of mkdocs for formatting and presentation.

Signed-off-by: Shyam <srangana@redhat.com>