### PR TITLE
Fix code block syntax in notes

### DIFF
--- a/Administrator Guide/Setting Up Volumes.md
+++ b/Administrator Guide/Setting Up Volumes.md
@@ -260,10 +260,9 @@ high-availability and high-reliability are critical.
 
     > - GlusterFS will fail to create a replicate volume if more than one brick of a replica set is present on the same peer. For eg. four node replicated volume with a more that one brick of a replica set is present on the same peer.
     > 
-    ```
-    # gluster volume create <volname> replica 4 server1:/brick1 server1:/brick2 server2:/brick3 server4:/brick4
-    volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal. Use 'force' at the end of the command if you want to override this behavior.
-    ```
+
+    >         # gluster volume create <volname> replica 4 server1:/brick1 server1:/brick2 server2:/brick3 server4:/brick4
+    >         volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal. Use 'force' at the end of the command if you want to override this behavior.
 
     >  Use the `force` option at the end of command if you want to create the volume in this case.
 
@@ -401,10 +400,9 @@ environments.
 
     > - GlusterFS will fail to create a distribute replicate volume if more than one brick of a replica set is present on the same peer. For eg. four node distribute (replicated) volume with a more than one brick of a replica set is present on the same peer.
     > 
-    ```
-    # gluster volume create <volname> replica 2 server1:/brick1 server1:/brick2 server2:/brick3 server4:/brick4
-    volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal. Use 'force' at the end of the command if you want to override this behavior.
-    ```
+
+    >         # gluster volume create <volname> replica 2 server1:/brick1 server1:/brick2 server2:/brick3 server4:/brick4
+    >         volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal. Use 'force' at the end of the command if you want to override this behavior.
 
     >  Use the `force` option at the end of command if you want to create the volume in this case.
 
@@ -448,10 +446,10 @@ Map Reduce workloads.
 
     > - GlusterFS will fail to create a distribute replicate volume if more than one brick of a replica set is present on the same peer. For eg. four node distribute (replicated) volume with a more than one brick of a replica set is present on the same peer.
     > 
-    ```
-    # gluster volume create <volname> stripe 2 replica 2 server1:/brick1 server1:/brick2 server2:/brick3 server4:/brick4
-    volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal. Use 'force' at the end of the command if you want to override this behavior.
-    ```
+
+    >         # gluster volume create <volname> stripe 2 replica 2 server1:/brick1 server1:/brick2 server2:/brick3 server4:/brick4
+    >         volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal. Use 'force' at the end of the command if you want to override this behavior.
+
     >  Use the `force` option at the end of command if you want to create the volume in this case.
 
 ## Creating Striped Replicated Volumes
@@ -500,10 +498,10 @@ of this volume type is supported only for Map Reduce workloads.
 
     > - GlusterFS will fail to create a distribute replicate volume if more than one brick of a replica set is present on the same peer. For eg. four node distribute (replicated) volume with a more than one brick of replica set is present on the same peer.
     > 
-    ```
-    # gluster volume create <volname> stripe 2 replica 2 server1:/brick1 server1:/brick2 server2:/brick3 server4:/brick4
-    volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal. Use `force` at the end of the command if you want to override this behavior.
-    ```
+
+    >         # gluster volume create <volname> stripe 2 replica 2 server1:/brick1 server1:/brick2 server2:/brick3 server4:/brick4
+    >         volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal. Use `force` at the end of the command if you want to override this behavior.
+
     >  Use the `force` option at the end of command if you want to create the volume in this case.
 
 ## Creating Dispersed Volumes
@@ -618,11 +616,11 @@ a RMW cycle for many writes (of course this always depends on the use case).
     > - GlusterFS will fail to create a dispersed volume if more than one brick of a disperse set is present on the same peer.
 
     > 
-    ```
-    # gluster volume create <volname> disperse 3 server1:/brick{1..3}
-    volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal.
-    Do you still want to continue creating the volume? (y/n)
-    ```
+
+    >         # gluster volume create <volname> disperse 3 server1:/brick{1..3}
+    >         volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal.
+    >         Do you still want to continue creating the volume? (y/n)
+
     >  Use the `force` option at the end of command if you want to create the volume in this case.
 
 
@@ -657,11 +655,11 @@ volumes, but using dispersed subvolumes instead of replicated ones.
     > - GlusterFS will fail to create a distributed dispersed volume if more than one brick of a disperse set is present on the same peer.
 
     > 
-    ```
-    # gluster volume create <volname> disperse 3 server1:/brick{1..6}
-    volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal.
-    Do you still want to continue creating the volume? (y/n)
-    ```
+
+    >         # gluster volume create <volname> disperse 3 server1:/brick{1..6}
+    >         volume create: <volname>: failed: Multiple bricks of a replicate volume are present on the same server. This setup is not optimal.
+    >         Do you still want to continue creating the volume? (y/n)
+
     > Use the `force` option at the end of command if you want to create the volume in this case.
 
 


### PR DESCRIPTION
Due to limitations of Markdown parser (or perhaps dialect differences compared to Github) when using the `mkdocs build`, the produced **Setting Up Volumes** HTML rendering will not correctly show the code blocks nested within the notes - the backtick syntax will not be detected, and will be shown verbatim in the document instead (so, basically, the text will not be rendered as code block).

This pull request fixes the issue by switching to "official" syntax that involves indentation instead of using the triple-backtick syntax.