### PR TITLE
Fix search for docs.gluster.org

### DIFF
--- a/js/fix-docs.js
+++ b/js/fix-docs.js
@@ -48,7 +48,7 @@
       }).appendTo(form);
     });
 
-    if (window.location.origin.indexOf('readthedocs') > -1) {
+    if (window.location.origin.indexOf('readthedocs') > -1 || window.location.origin.indexOf('docs.gluster.org') > -1) {
       observer.observe(target, config);
     }
   }


### PR DESCRIPTION
The previous fix only worked on gluster.readthedocs.io.

Fixes gluster/community#16