### PR TITLE
add proper arch into sources path

### DIFF
--- a/Install-Guide/Install.md
+++ b/Install-Guide/Install.md
@@ -24,7 +24,8 @@ Add the source:
 
     DEBID=$(grep 'VERSION_ID=' /etc/os-release | cut -d '=' -f 2 | tr -d '"')
     DEBVER=$(grep 'VERSION=' /etc/os-release | grep -Eo '[a-z]+')
-    echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list
+    DEBARCH=$(dpkg --print-architecture)
+    echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/${DEBARCH}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list
 
 Update package list:
 


### PR DESCRIPTION
Without arch in link `apt-get update` does not work:
```
Ign:6 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch InRelease
Ign:7 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch Release
Ign:8 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main amd64 Packages
Ign:9 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main all Packages
Ign:10 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en_US
Ign:11 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en
Ign:8 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main amd64 Packages
Ign:9 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main all Packages
Ign:10 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en_US
Ign:11 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en
Ign:8 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main amd64 Packages
Ign:9 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main all Packages
Ign:10 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en_US
Ign:11 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en
Ign:8 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main amd64 Packages
Ign:9 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main all Packages
Ign:10 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en_US
Ign:11 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en
Ign:8 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main amd64 Packages
Ign:9 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main all Packages
Ign:10 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en_US
Ign:11 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en
Err:8 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main amd64 Packages
  404  Not Found
Ign:9 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main all Packages
Ign:10 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en_US
Ign:11 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch/main Translation-en
Reading package lists... Done
W: The repository 'https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt stretch Release' does not have a Release file.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: Failed to fetch https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/apt/dists/stretch/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
```
after change I could sucessful done `apt-get update`
```
root@gluster1:~# DEBID=$(grep 'VERSION_ID=' /etc/os-release | cut -d '=' -f 2 | tr -d '"')
root@gluster1:~# DEBVER=$(grep 'VERSION=' /etc/os-release | grep -Eo '[a-z]+')
root@gluster1:~# DEBARCH=$(dpkg --print-architecture)
root@gluster1:~#     echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/${DEBARCH}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list
root@cdn1:~# apt-get update
Ign:1 http://ftp.icm.edu.pl/pub/Linux/debian stretch InRelease
Hit:2 http://ftp.icm.edu.pl/pub/Linux/debian stretch-updates InRelease
Hit:3 http://ftp.icm.edu.pl/pub/Linux/debian stretch Release
Hit:4 http://security.debian.org/debian-security stretch/updates InRelease
Hit:6 https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/amd64/apt stretch InRelease
Reading package lists... Done
```