### PR TITLE
Added release notes for 4.1.2 release

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ pages:
   - Upgrade to 4.1: Upgrade-Guide/upgrade_to_4.1.md
 - Release Notes:
   - index: release-notes/index.md
+  - 4.1.2: release-notes/4.1.2.md
   - 4.1.1: release-notes/4.1.1.md
   - 4.1.0: release-notes/4.1.0.md
   - 4.0.2: release-notes/4.0.2.md

--- a/release-notes/4.1.2.md
+++ b/release-notes/4.1.2.md
@@ -1,0 +1,32 @@
+# Release notes for Gluster 4.1.2
+
+This is a bugfix release. The release notes for [4.1.0](4.1.0.md) and [4.1.1](4.1.1.md) contains a
+listing of all the new features that were added and bugs fixed in the
+GlusterFS 4.1 stable release.
+
+## Major changes, features and limitations addressed in this release
+
+1. Release 4.1.0 [notes](4.1.0.md) *incorrectly* reported that all python code in
+Gluster packages are python3 compliant, this is not the case and the release
+note is amended accordingly.
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-4.1.1 are listed below.
+
+- [#1593536](https://bugzilla.redhat.com/1593536): ctime: Self heal of symlink is failing on EC subvolume
+- [#1593537](https://bugzilla.redhat.com/1593537): posix/ctime: Mdata value of a directory is different across replica/EC subvolume
+- [#1595524](https://bugzilla.redhat.com/1595524): rmdir is leaking softlinks to directories in .glusterfs
+- [#1597116](https://bugzilla.redhat.com/1597116): afr: don't update readables if inode refresh failed on all children
+- [#1597117](https://bugzilla.redhat.com/1597117): lookup not assigning gfid if file is not present in all bricks of replica
+- [#1597229](https://bugzilla.redhat.com/1597229): glustershd crashes when index heal is launched before graph is initialized.
+- [#1598193](https://bugzilla.redhat.com/1598193): Stale lock with lk-owner all-zeros is observed in some tests
+- [#1599629](https://bugzilla.redhat.com/1599629): Don't execute statements after decrementing call count in afr
+- [#1599785](https://bugzilla.redhat.com/1599785): _is_prefix should return false for 0-length strings
+- [#1600941](https://bugzilla.redhat.com/1600941): [geo-rep]: geo-replication scheduler is failing due to unsuccessful umount
+- [#1603056](https://bugzilla.redhat.com/1603056): When reserve limits are reached, append on an existing file after truncate operation results to hang
+- [#1603099](https://bugzilla.redhat.com/1603099): directories are invisible on client side

--- a/release-notes/index.md
+++ b/release-notes/index.md
@@ -3,6 +3,7 @@ Release Notes
 
 ### GlusterFS 4.1 release notes
 
+- [4.1.2](./4.1.2.md)
 - [4.1.1](./4.1.1.md)
 - [4.1.0](./4.1.0.md)
 


### PR DESCRIPTION
Further reference to the release notes, as below,
https://github.com/gluster/glusterfs/blob/v4.1.2/doc/release-notes/4.1.2.md

Signed-off-by: ShyamsundarR <srangana@redhat.com>