### PR TITLE
Corrected 4.1.0 release notes to remove py3 compliance feature

### DIFF
--- a/release-notes/4.1.0.md
+++ b/release-notes/4.1.0.md
@@ -255,12 +255,7 @@ the initial server used to fetch the volfile and mount is down.
 When using glusterd, this is achieved using the FUSE mount option
 `backup-volfile-servers`, and when using GlusterD2 this is done automatically.
 
-#### 3. Python code base is now python3 compatible
-
-All python code in Gluster that are installed by the various packages are
-python3 compatible.
-
-#### 4. (c/m)time equivalence across replicate and disperse subvolumes
+#### 3. (c/m)time equivalence across replicate and disperse subvolumes
 
 Enabling the utime feature, enables Gluster to maintain consistent change and
 modification time stamps on files and directories across bricks.


### PR DESCRIPTION
Reference to the change is present in 4.1.2 release notes as well.

Signed-off-by: ShyamsundarR <srangana@redhat.com>