### PR TITLE
Corrected two outdated mailing list links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ the "Edit on GitHub" link on the top right corner of each page. If you already h
 account, you can simply edit the document in your browser, use the preview tab, and submit
 your changes for review in a pull request.
 
-If you want to help more with Gluster documentation, please subscribe to [Gluster
-Users](http://www.gluster.org/mailman/listinfo/gluster-users) and [Gluster
-Developers](http://www.gluster.org/mailman/listinfo/gluster-devel) mailing lists,
+If you want to help more with Gluster documentation, please subscribe to the [Gluster
+Users](https://lists.gluster.org/mailman/listinfo/gluster-users) and [Gluster
+Developers](https://lists.gluster.org/mailman/listinfo/gluster-devel) mailing lists,
 and share your ideas with the Gluster developer community.


### PR DESCRIPTION
Just noticed these are outdated when looking for the mailing list info (seems completely absent from the website too?).

With these two updated links, the gluster-devel one is kind of optional as there a redirect in place on the existing url to take people there.  The gluster-users one is needed though, as the current link doesn't have a redirect so 404's.