### PR TITLE
Line space missed, causing bug list to appear in a single line

### DIFF
--- a/docs/release-notes/5.0.md
+++ b/docs/release-notes/5.0.md
@@ -194,6 +194,7 @@ upgrading the cluster.
 ## Bugs addressed
 
 Bugs addressed since release-4.1.0 are listed below.
+
 - [#853601](https://bugzilla.redhat.com/853601): working-directory should be protected from being a brick
 - [#1312832](https://bugzilla.redhat.com/1312832): tests fail because bug-924726.t depends on netstat
 - [#1390050](https://bugzilla.redhat.com/1390050): Elasticsearch get CorruptIndexException errors when running with GlusterFS persistent storage


### PR DESCRIPTION
This is now fixed!

Signed-off-by: ShyamsundarR <srangana@redhat.com>