### PR TITLE
added correct link for gluster-devel mailing list

### DIFF
--- a/docs/Developer-guide/Fixing-issues-reported-by-tools-for-static-code-analysis.md
+++ b/docs/Developer-guide/Fixing-issues-reported-by-tools-for-static-code-analysis.md
@@ -29,7 +29,7 @@ program.
     understand the reasoning behind it.
 
 *If you have more questions please send it to
-[gluster-devel](http://www.gluster.org/interact/mailinglists) mailing
+[gluster-devel](https://lists.gluster.org/mailman/listinfo/gluster-devel) mailing
 list*
 
 ### CPP Check


### PR DESCRIPTION
Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>
Updated link of mailing list
Fixes #486