### PR TITLE
ctdb requires CTDB_SAMBA_SKIP_SHARE_CHECK to be set

### DIFF
--- a/docs/Administrator Guide/Accessing Gluster from Windows.md
+++ b/docs/Administrator Guide/Accessing Gluster from Windows.md
@@ -58,7 +58,8 @@ The servers may/may not be part of the trusted storage pool. Preferable number o
    192.168.1.20/24 eth0
    192.168.1.21/24 eth0
    ```
- 7. If SELinux is enabled and enforcing, try the following command if ctdb fails.  
+ 7. Uncomment	`CTDB_SAMBA_SKIP_SHARE_CHECK=yes` in /etc/ctdb/script.options to disable checking of the shares by ctdb
+ 8. If SELinux is enabled and enforcing, try the following command if ctdb fails.  
    ```
    # setsebool -P use_fusefs_home_dirs 1
    # setsebool -P samba_load_libgfapi 1

--- a/docs/Administrator Guide/Accessing Gluster from Windows.md
+++ b/docs/Administrator Guide/Accessing Gluster from Windows.md
@@ -58,7 +58,7 @@ The servers may/may not be part of the trusted storage pool. Preferable number o
    192.168.1.20/24 eth0
    192.168.1.21/24 eth0
    ```
- 7. Uncomment	`CTDB_SAMBA_SKIP_SHARE_CHECK=yes` in /etc/ctdb/script.options to disable checking of the shares by ctdb
+ 7. Either uncomment `CTDB_SAMBA_SKIP_SHARE_CHECK=yes` or add `CTDB_SAMBA_SKIP_SHARE_CHECK=yes in its absence inside /etc/ctdb/script.options to disable checking of the shares by ctdb.
  8. If SELinux is enabled and enforcing, try the following command if ctdb fails.  
    ```
    # setsebool -P use_fusefs_home_dirs 1


### PR DESCRIPTION
As mentioned at https://www.samba.org/samba/docs/current/man-html/vfs_glusterfs.8.html ctdb checks the path as an absolute path and does not differentiate this for vfs_glusterfs. Therefore ctdb will generate errors if a path is set in the share that does not also exist in the os's file system.
Eg. using `path /` in a samba share config works as it exists in the os files system while `path /blob` might exist in the glusterfs volume but not in the os file system and as such would generate an error