### PR TITLE
Markdown code highlight fixes

### DIFF
--- a/docs/Administrator Guide/Access Control Lists.md
+++ b/docs/Administrator Guide/Access Control Lists.md
@@ -22,27 +22,37 @@ directory must be mounted with POSIX ACLs support.
 To mount the backend export directories for POSIX ACLs support, use the
 following command:
 
-`# mount -o acl `
+```console
+# mount -o acl
+```
 
 For example:
 
-`# mount -o acl /dev/sda1 /export1 `
+```console
+# mount -o acl /dev/sda1 /export1
+```
 
 Alternatively, if the partition is listed in the /etc/fstab file, add
 the following entry for the partition to include the POSIX ACLs option:
 
-`LABEL=/work /export1 ext3 rw, acl 14 `
+```text
+LABEL=/work /export1 ext3 rw, acl 14
+```
 
 ### Activating POSIX ACLs Support on Client
 
 To mount the glusterfs volumes for POSIX ACLs support, use the following
 command:
 
-`# mount –t glusterfs -o acl `
+```console
+# mount –t glusterfs -o acl
+```
 
 For example:
 
-`# mount -t glusterfs -o acl 198.192.198.234:glustervolume /mnt/gluster`
+```console
+# mount -t glusterfs -o acl 198.192.198.234:glustervolume /mnt/gluster
+```
 
 ## Setting POSIX ACLs
 
@@ -64,7 +74,9 @@ directories.
 
 You can set or modify access ACLs use the following command:
 
-`# setfacl –m  file `
+```console
+# setfacl –m  file
+```
 
 The ACL entry types are the POSIX ACLs representations of owner, group,
 and other.
@@ -87,7 +99,9 @@ POSIX ACLs or the existing rule is modified.
 
 For example, to give read and write permissions to user antony:
 
-`# setfacl -m u:antony:rw /mnt/gluster/data/testfile `
+```console
+# setfacl -m u:antony:rw /mnt/gluster/data/testfile
+```
 
 ## Setting Default ACLs
 
@@ -100,7 +114,9 @@ To set default ACLs
 You can set default ACLs for files and directories using the following
 command:
 
-`# setfacl –m –-set `
+```console
+# setfacl –m –-set
+```
 
 Permissions must be a combination of the characters r (read), w (write), and x (execute). Specify the ACL entry_type as described below, separating multiple entry types with commas.
 
@@ -119,8 +135,9 @@ o:*permissions*
 For example, to set the default ACLs for the /data directory to read for
 users not in the user group:
 
-`# setfacl –m --set o::r /mnt/gluster/data `
-
+```console
+# setfacl –m --set o::r /mnt/gluster/data
+```
 > **Note**
 >
 > An access ACLs set for an individual file can override the default
@@ -143,7 +160,7 @@ You can view the existing POSIX ACLs for a file or directory.
 
 -   View the existing access ACLs of a file using the following command:
 
-    `# getfacl `
+        # getfacl
 
     For example, to view the existing POSIX ACLs for sample.jpg
 
@@ -156,7 +173,7 @@ You can view the existing POSIX ACLs for a file or directory.
 
 -   View the default ACLs of a directory using the following command:
 
-    `# getfacl `
+        # getfacl
 
     For example, to view the existing ACLs for /data/doc
 
@@ -179,7 +196,9 @@ You can view the existing POSIX ACLs for a file or directory.
 To remove all the permissions for a user, groups, or others, use the
 following command:
 
-`# setfacl -x `
+```console
+# setfacl -x
+```
 
 #### setfaclentry_type Options
 
@@ -201,7 +220,9 @@ o:*permissions*
 
 For example, to remove all permissions from the user antony:
 
-`# setfacl -x u:antony /mnt/gluster/data/test-file`
+```console
+# setfacl -x u:antony /mnt/gluster/data/test-file
+```
 
 ## Samba and ACLs
 

--- a/docs/Administrator Guide/Directory Quota.md
+++ b/docs/Administrator Guide/Directory Quota.md
@@ -30,15 +30,18 @@ You must enable Quota to set disk limits.
 
 **To enable quota:**
 
--   Use the following command to enable quota:
+Use the following command to enable quota:
 
-        # gluster volume quota VOLNAME enable
-
+```console
+# gluster volume quota VOLNAME enable
+```
 
 For example, to enable quota on the test-volume:
 
-        # gluster volume quota test-volume enable
-        Quota is enabled on /test-volume
+```console
+# gluster volume quota test-volume enable
+Quota is enabled on /test-volume
+```
 
 ## Disabling Quota
 
@@ -46,14 +49,18 @@ You can disable Quota, if needed.
 
 **To disable quota:**
 
--   Use the following command to disable quota:
+Use the following command to disable quota:
 
-        # gluster volume quota VOLNAME disable
+```console
+# gluster volume quota VOLNAME disable
+```
 
 For example, to disable quota translator on the test-volume:
 
-        # gluster volume quota test-volume disable
-        Quota translator is disabled on /test-volume
+```console
+# gluster volume quota test-volume disable
+Quota translator is disabled on /test-volume
+```
 
 ## Setting or Replacing Disk Limit
 
@@ -64,15 +71,19 @@ being treated as "/".
 
 **To set or replace disk limit:**
 
--   Set the disk limit using the following command:
+Set the disk limit using the following command:
 
-                # gluster volume quota VOLNAME limit-usage DIR HARD_LIMIT
+```console
+# gluster volume quota VOLNAME limit-usage DIR HARD_LIMIT
+```
 
 For example, to set limit on data directory on the test-volume where
 data is a directory under the export directory:
 
-        # gluster volume quota test-volume limit-usage /data 10GB
-        Usage limit has been set on /data
+```console
+# gluster volume quota test-volume limit-usage /data 10GB
+Usage limit has been set on /data
+```
 
 > **Note**
 > In a multi-level directory hierarchy, the strictest disk limit
@@ -95,18 +106,18 @@ the limit is set.
 
         # gluster volume quota VOLNAME list
 
-For example, to see the set disks limit on the test-volume:
+    For example, to see the set disks limit on the test-volume:
 
         # gluster volume quota test-volume list
-          /Test/data    10 GB       6 GB
-          /Test/data1   10 GB       4 GB
+        /Test/data    10 GB       6 GB
+        /Test/data1   10 GB       4 GB
 
 -   Display disk limit information on a particular directory on which
     limit is set, using the following command:
 
         # gluster volume quota VOLNAME list DIR
 
-For example, to view the set limit on /data directory of test-volume:
+    For example, to view the set limit on /data directory of test-volume:
 
         # gluster volume quota test-volume list /data
         /Test/data    10 GB       6 GB
@@ -116,7 +127,9 @@ For example, to view the set limit on /data directory of test-volume:
 
 You can create a report of the disk usage using the df utility by taking quota limits into consideration. To generate a report, run the following command:
 
-        # gluster volume set VOLNAME quota-deem-statfs on
+```console
+# gluster volume set VOLNAME quota-deem-statfs on
+```
 
 In this case, the total disk space of the directory is taken as the quota hard limit set on the directory of the volume.
 
@@ -125,35 +138,43 @@ In this case, the total disk space of the directory is taken as the quota hard l
 
 The following example displays the disk usage when quota-deem-statfs is off:
 
-        # gluster volume set test-volume features.quota-deem-statfs off
-        volume set: success
-        # gluster volume quota test-volume list
-        Path        Hard-limit    Soft-limit     Used     Available
-        ----------------------------------------------------------- 
-          /              300.0GB        90%        11.5GB     288.5GB
-         /John/Downloads 77.0GB        75%        11.5GB     65.5GB
+```console
+# gluster volume set test-volume features.quota-deem-statfs off
+volume set: success
+# gluster volume quota test-volume list
+Path            Hard-limit    Soft-limit    Used      Available
+--------------------------------------------------------------- 
+/               300.0GB        90%          11.5GB    288.5GB
+/John/Downloads  77.0GB        75%          11.5GB     65.5GB
+```
 
 Disk usage for volume test-volume as seen on client1:
 
-        # df -hT /home
-          Filesystem           Type            Size  Used Avail Use% Mounted on
-          server1:/test-volume fuse.glusterfs  400G   12G  389G   3% /home
+```console
+# df -hT /home
+Filesystem           Type            Size  Used Avail Use% Mounted on
+server1:/test-volume fuse.glusterfs  400G   12G  389G   3% /home
+```
 
 The following example displays the disk usage when quota-deem-statfs is on:
 
-        # gluster volume set test-volume features.quota-deem-statfs on
-        volume set: success
-        # gluster vol quota test-volume list
-        Path        Hard-limit    Soft-limit     Used     Available
-        -----------------------------------------------------------
-        /              300.0GB        90%        11.5GB     288.5GB
-        /John/Downloads 77.0GB        75%        11.5GB     65.5GB
+```console
+# gluster volume set test-volume features.quota-deem-statfs on
+volume set: success
+# gluster vol quota test-volume list
+Path        Hard-limit    Soft-limit     Used     Available
+-----------------------------------------------------------
+/              300.0GB        90%        11.5GB     288.5GB
+/John/Downloads 77.0GB        75%        11.5GB     65.5GB
+```
 
 Disk usage for volume test-volume as seen on client1:
 
-        # df -hT /home
-        Filesystem            Type            Size  Used Avail Use% Mounted on
-        server1:/test-volume  fuse.glusterfs  300G   12G  289G   4% /home
+```console
+# df -hT /home
+Filesystem            Type            Size  Used Avail Use% Mounted on
+server1:/test-volume  fuse.glusterfs  300G   12G  289G   4% /home
+```
 
 The quota-deem-statfs option when set to on, allows the administrator to make the user view the total disk space available on the directory as the hard limit set on it.
 
@@ -180,25 +201,30 @@ on client side.
 
 **To update the memory cache size:**
 
--   Use the following command to update the memory cache size:
+Use the following command to update the memory cache size:
 
-        # gluster volume set VOLNAME features.quota-timeout time
+```console
+# gluster volume set VOLNAME features.quota-timeout time
+```
 
-For example, to update the memory cache size for every 5 seconds on
-test-volume:
+For example, to update the memory cache size for every 5 seconds on test-volume:
 
-        # gluster volume set test-volume features.quota-timeout 5
-        Set volume successful
- 
+```console
+# gluster volume set test-volume features.quota-timeout 5
+Set volume successful
+```
+
 ## Setting Alert Time
 
 Alert time is the frequency at which you want your usage information to be logged after you reach the soft limit.
 
 **To set the alert time:**
 
--  Use the following command to set the alert time:
+Use the following command to set the alert time:
 
-        # gluster volume quota VOLNAME alert-time time
+```console
+# gluster volume quota VOLNAME alert-time time
+```
 
 >**Note**
 >
@@ -206,8 +232,10 @@ Alert time is the frequency at which you want your usage information to be logge
 
 For example, to set the alert time to one day:
 
-        # gluster volume quota test-volume alert-time 1d
-        volume quota : success
+```console
+# gluster volume quota test-volume alert-time 1d
+volume quota : success
+```
 
 ## Removing Disk Limit
 
@@ -215,14 +243,16 @@ You can remove set disk limit, if you do not want quota anymore.
 
 **To remove disk limit:**
 
--   Use the following command to remove the disk limit set on a particular directory:
+Use the following command to remove the disk limit set on a particular directory:
 
-        # gluster volume quota VOLNAME remove DIR
+```console
+# gluster volume quota VOLNAME remove DIR
+```
 
 For example, to remove the disk limit on /data directory of
 test-volume:
 
-
-        # gluster volume quota test-volume remove /data
-        Usage limit set on /data is removed
-
+```console
+# gluster volume quota test-volume remove /data
+Usage limit set on /data is removed
+```

--- a/docs/Administrator Guide/Events APIs.md
+++ b/docs/Administrator Guide/Events APIs.md
@@ -7,8 +7,9 @@ If Gluster is installed using source install, `cliutils` will get
 installed under `/usr/local/lib/python.2.7/site-packages` Set
 PYTHONPATH by adding in `~/.bashrc`
 
-    export PYTHONPATH=/usr/local/lib/python2.7/site-packages:$PYTHONPATH
-
+```console
+# export PYTHONPATH=/usr/local/lib/python2.7/site-packages:$PYTHONPATH
+```
 
 ## Enable and Start Events APIs
 
@@ -16,39 +17,51 @@ Enable and Start glustereventsd in all peer nodes
 
 In Systems using Systemd,
 
-    systemctl enable glustereventsd
-    systemctl start glustereventsd
+```console
+# systemctl enable glustereventsd
+# systemctl start glustereventsd
+```
 
 FreeBSD or others, add the following in `/etc/rc.conf`
 
-    glustereventsd_enable="YES"
+```text
+glustereventsd_enable="YES"
+```
 
 And start the glustereventsd using,
 
-    service glustereventsd start
+```console
+# service glustereventsd start
+```
 
 SysVInit(CentOS 6),
 
-    chkconfig glustereventsd on
-    service glustereventsd start
+```console
+# chkconfig glustereventsd on
+# service glustereventsd start
+```
 
 ## Status
 
 Status Can be checked using,
 
-    gluster-eventsapi status
+```console
+# gluster-eventsapi status
+```
 
 Example output:
 
-    Webhooks:
-    None
+```console
+Webhooks:
+None
 
-    +-----------+-------------+-----------------------+
-    |    NODE   | NODE STATUS | GLUSTEREVENTSD STATUS |
-    +-----------+-------------+-----------------------+
-    | localhost |          UP |                    UP |
-    | node2     |          UP |                    UP |
-    +-----------+-------------+-----------------------+
++-----------+-------------+-----------------------+
+| NODE      | NODE STATUS | GLUSTEREVENTSD STATUS |
++-----------+-------------+-----------------------+
+| localhost |          UP |                    UP |
+| node2     |          UP |                    UP |
++-----------+-------------+-----------------------+
+```
 
 ## Webhooks
 **Webhooks** are similar to callbacks(over HTTP), on event Gluster will
@@ -59,152 +72,180 @@ the configured port.
 
 Example Webhook written in python,
 
-    from flask import Flask, request
+```python
+from flask import Flask, request
 
-    app = Flask(__name__)
+app = Flask(__name__)
 
-    @app.route("/listen", methods=["POST"])
-    def events_listener():
-        gluster_event = request.json
-        if gluster_event is None:
-            # No event to process, may be test call
-            return "OK"
-
-        # Process gluster_event
-        # {
-        #  "nodeid": NODEID,
-        #  "ts": EVENT_TIMESTAMP,
-        #  "event": EVENT_TYPE,
-        #  "message": EVENT_DATA
-        # }
-        print (gluster_event)
+@app.route("/listen", methods=["POST"])
+def events_listener():
+    gluster_event = request.json
+    if gluster_event is None:
+        # No event to process, may be test call
         return "OK"
 
-    app.run(host="0.0.0.0", port=9000)
+    # Process gluster_event
+    # {
+    #  "nodeid": NODEID,
+    #  "ts": EVENT_TIMESTAMP,
+    #  "event": EVENT_TYPE,
+    #  "message": EVENT_DATA
+    # }
+    print (gluster_event)
+    return "OK"
+
+app.run(host="0.0.0.0", port=9000)
+```
 
 Test and Register webhook using following commands,
 
-    usage: gluster-eventsapi webhook-test [-h] [--bearer_token BEARER_TOKEN] url
+```console
+usage: gluster-eventsapi webhook-test [-h] [--bearer_token BEARER_TOKEN] url
 
-    positional arguments:
-      url                   URL of Webhook
+positional arguments:
+  url                   URL of Webhook
 
-    optional arguments:
-      -h, --help            show this help message and exit
-      --bearer_token BEARER_TOKEN, -t BEARER_TOKEN
-                            Bearer Token
+optional arguments:
+  -h, --help            show this help message and exit
+  --bearer_token BEARER_TOKEN, -t BEARER_TOKEN
+                        Bearer Token
+```
 
 Example(Webhook server is running in `192.168.122.188:9000`),
 
-    gluster-eventsapi webhook-test http://192.168.122.188:9000/listen
+```console
+# gluster-eventsapi webhook-test http://192.168.122.188:9000/listen
 
-    +-----------+-------------+----------------+
-    |    NODE   | NODE STATUS | WEBHOOK STATUS |
-    +-----------+-------------+----------------+
-    | localhost |          UP |             OK |
-    | node2     |          UP |             OK |
-    +-----------+-------------+----------------+
++-----------+-------------+----------------+
+| NODE      | NODE STATUS | WEBHOOK STATUS |
++-----------+-------------+----------------+
+| localhost |          UP |             OK |
+| node2     |          UP |             OK |
++-----------+-------------+----------------+
+```
 
 If Webhook status is OK from all peer nodes then register the Webhook
 using,
 
-    usage: gluster-eventsapi webhook-add [-h] [--bearer_token BEARER_TOKEN] url
+```console
+usage: gluster-eventsapi webhook-add [-h] [--bearer_token BEARER_TOKEN] url
 
-    positional arguments:
-      url                   URL of Webhook
+positional arguments:
+  url                   URL of Webhook
 
-    optional arguments:
-      -h, --help            show this help message and exit
-      --bearer_token BEARER_TOKEN, -t BEARER_TOKEN
-                            Bearer Token
+optional arguments:
+  -h, --help            show this help message and exit
+  --bearer_token BEARER_TOKEN, -t BEARER_TOKEN
+                        Bearer Token
+```
 
 Example,
 
-    gluster-eventsapi webhook-add http://192.168.122.188:9000/listen
+```console
+# gluster-eventsapi webhook-add http://192.168.122.188:9000/listen
 
-    +-----------+-------------+-------------+
-    |    NODE   | NODE STATUS | SYNC STATUS |
-    +-----------+-------------+-------------+
-    | localhost |          UP |          OK |
-    | node2     |          UP |          OK |
-    +-----------+-------------+-------------+
++-----------+-------------+-------------+
+| NODE      | NODE STATUS | SYNC STATUS |
++-----------+-------------+-------------+
+| localhost |          UP |          OK |
+| node2     |          UP |          OK |
++-----------+-------------+-------------+
+```
 
 **Note**: If Sync status is Not OK for any node, then make sure to run
 following command from a peer node when that node comes up.
 
-    gluster-eventsapi sync
+```console
+# gluster-eventsapi sync
+```
 
 To unsubscribe from events, delete the webhook using following command
 
-    usage: gluster-eventsapi webhook-del [-h] url
+```console
+usage: gluster-eventsapi webhook-del [-h] url
 
-    positional arguments:
-      url         URL of Webhook
+positional arguments:
+  url         URL of Webhook
 
-    optional arguments:
-      -h, --help  show this help message and exit
+optional arguments:
+  -h, --help  show this help message and exit
+```
 
 Example,
 
-    gluster-eventsapi webhook-del http://192.168.122.188:9000/listen
+```console
+# gluster-eventsapi webhook-del http://192.168.122.188:9000/listen
+```
 
 ## Configuration
 
 View all configurations using,
 
-    usage: gluster-eventsapi config-get [-h] [--name NAME]
+```console
+usage: gluster-eventsapi config-get [-h] [--name NAME]
 
-    optional arguments:
-      -h, --help   show this help message and exit
-      --name NAME  Config Name
+optional arguments:
+  -h, --help   show this help message and exit
+  --name NAME  Config Name
+```
 
 Example output:
 
-    +-----------+-------+
-    |    NAME   | VALUE |
-    +-----------+-------+
-    | log_level | INFO  |
-    |    port   | 24009 |
-    +-----------+-------+
+```console
++-----------+-------+
+| NAME      | VALUE |
++-----------+-------+
+| log_level | INFO  |
+| port      | 24009 |
++-----------+-------+
+```
 
 To change any configuration,
 
-    usage: gluster-eventsapi config-set [-h] name value
+```console
+usage: gluster-eventsapi config-set [-h] name value
 
-    positional arguments:
-      name        Config Name
-      value       Config Value
+positional arguments:
+  name        Config Name
+  value       Config Value
 
-    optional arguments:
-      -h, --help  show this help message and exit
+optional arguments:
+  -h, --help  show this help message and exit
+```
 
 Example output,
 
-    +-----------+-------------+-------------+
-    |    NODE   | NODE STATUS | SYNC STATUS |
-    +-----------+-------------+-------------+
-    | localhost |          UP |          OK |
-    | node2     |          UP |          OK |
-    +-----------+-------------+-------------+
+```console
++-----------+-------------+-------------+
+| NODE      | NODE STATUS | SYNC STATUS |
++-----------+-------------+-------------+
+| localhost |          UP |          OK |
+| node2     |          UP |          OK |
++-----------+-------------+-------------+
+```
 
 To Reset any configuration,
 
-    usage: gluster-eventsapi config-reset [-h] name
+```console
+usage: gluster-eventsapi config-reset [-h] name
 
-    positional arguments:
-      name        Config Name or all
+positional arguments:
+  name        Config Name or all
 
-    optional arguments:
-      -h, --help  show this help message and exit
+optional arguments:
+  -h, --help  show this help message and exit
+```
 
 Example output,
 
-    +-----------+-------------+-------------+
-    |    NODE   | NODE STATUS | SYNC STATUS |
-    +-----------+-------------+-------------+
-    | localhost |          UP |          OK |
-    | node2     |          UP |          OK |
-    +-----------+-------------+-------------+
+```console
++-----------+-------------+-------------+
+| NODE      | NODE STATUS | SYNC STATUS |
++-----------+-------------+-------------+
+| localhost |          UP |          OK |
+| node2     |          UP |          OK |
++-----------+-------------+-------------+
+```
 
 **Note**: If any node status is not UP or sync status is not OK, make
 sure to run `gluster-eventsapi sync` from a peer node.
@@ -230,14 +271,16 @@ message   | Event Specific Data
 
 Example:
 
-    {
-            "nodeid": "95cd599c-5d87-43c1-8fba-b12821fd41b6",
-            "ts": 1468303352,
-            "event": "VOLUME_CREATE",
-            "message": {
-                "name": "gv1"
-            }
+```json
+{
+    "nodeid": "95cd599c-5d87-43c1-8fba-b12821fd41b6",
+    "ts": 1468303352,
+    "event": "VOLUME_CREATE",
+    "message": {
+        "name": "gv1"
     }
+}
+```
 
 "message" can have following attributes based on the type of event.
 

--- a/docs/Administrator Guide/Geo Replication.md
+++ b/docs/Administrator Guide/Geo Replication.md
@@ -14,14 +14,15 @@ mirroring occurs between the following partners:
 
 - **Session** - Unique identifier of Geo-replication session `<MASTER_VOL> [<SLAVE_USER>@]<PRIMARY_SLAVE_HOST>::<SLAVE_VOL>`
 
-        Where,
+```text
+Where,
 
-        MASTER_VOL - Master Volume Name
-        SLAVE_USER - Slave user used to establish the session, Default is root
-        PRIMARY_SLAVE_HOST - Any one Slave node to which password-less
-            SSH is setup to establish session
-        SLAVE_VOL - Slave Volume Name
-
+MASTER_VOL - Master Volume Name
+SLAVE_USER - Slave user used to establish the session, Default is root
+PRIMARY_SLAVE_HOST - Any one Slave node to which password-less
+    SSH is setup to establish session
+SLAVE_VOL - Slave Volume Name
+```
     
 ## Replicated Volumes vs Geo-replication
 
@@ -116,7 +117,7 @@ Following steps to be performed to setup Non root Slave user
 
     For example,
 
-        gluster-mountbroker setup /var/mountbroker-root geogroup
+        # gluster-mountbroker setup /var/mountbroker-root geogroup
 
 4. In any one of Slave node, Run the following commands to add Volume
    and user to mountbroker service.
@@ -125,7 +126,7 @@ Following steps to be performed to setup Non root Slave user
 
     For example,
 
-        gluster-mountbroker add slavevol geoaccount
+        # gluster-mountbroker add slavevol geoaccount
 
     Remove user or Volume using,
 
@@ -133,13 +134,13 @@ Following steps to be performed to setup Non root Slave user
 
     Example,
 
-        gluster-mountbroker remove --volume slavevol --user geoaccount
-        gluster-mountbroker remove --user geoaccount
-        gluster-mountbroker remove --volume slavevol
+        # gluster-mountbroker remove --volume slavevol --user geoaccount
+        # gluster-mountbroker remove --user geoaccount
+        # gluster-mountbroker remove --volume slavevol
 
     Check the status of setup using,
 
-        gluster-mountbroker status
+        # gluster-mountbroker status
 
 5.  Restart `glusterd` service on all Slave nodes.
 
@@ -158,35 +159,27 @@ Following steps to be performed to setup Non root Slave user
 file(`/etc/glusterfs/glusterd.vol`)
     in rpm installations and `/usr/local/etc/glusterfs/glusterd.vol` in Source installation.
 
-```sh
-    gluster system:: execute mountbroker opt mountbroker-root /var/mountbroker-root
-    gluster system:: execute mountbroker opt geo-replication-log-group geogroup
-    gluster system:: execute mountbroker opt rpc-auth-allow-insecure on
-```
+        # gluster system:: execute mountbroker opt mountbroker-root /var/mountbroker-root
+        # gluster system:: execute mountbroker opt geo-replication-log-group geogroup
+        # gluster system:: execute mountbroker opt rpc-auth-allow-insecure on
 
 5.  In any one of the Slave node, Add Mountbroker user to glusterd vol file using,
 
-```sh
-    gluster system:: execute mountbroker user geoaccount slavevol
-```
+        # gluster system:: execute mountbroker user geoaccount slavevol
 
     where slavevol is the Slave Volume name
 
-    If you host multiple slave volumes on Slave, for each of them and add the following options
-to the volfile using,
+    If you host multiple slave volumes on Slave, for each of them and add the following options to the volfile using,
 
-```sh
-    gluster system:: execute mountbroker user geoaccount2 slavevol2
-    gluster system:: execute mountbroker user geoaccount3 slavevol3
-```
+        # gluster system:: execute mountbroker user geoaccount2 slavevol2
+        # gluster system:: execute mountbroker user geoaccount3 slavevol3
 
     To add multiple volumes per mountbroker user,
 
-```sh
-    gluster system:: execute mountbroker user geoaccount1 slavevol11,slavevol12,slavevol13
-    gluster system:: execute mountbroker user geoaccount2 slavevol21,slavevol22
-    gluster system:: execute mountbroker user geoaccount3 slavevol31
-```
+        # gluster system:: execute mountbroker user geoaccount1 slavevol11,slavevol12,slavevol13
+        # gluster system:: execute mountbroker user geoaccount2 slavevol21,slavevol22
+        # gluster system:: execute mountbroker user geoaccount3 slavevol31
+
 6.  Restart `glusterd` service on all Slave nodes.
 
 ## Setting Up the Environment for Geo-replication
@@ -213,7 +206,7 @@ once session is established.(Required again while running create force)
 1.  On one of the Master node where geo-replication Create command
     will be issued, run the following command to generate the SSH key.
 
-        ssh-keygen
+        # ssh-keygen
 
     Press Enter twice to avoid passphrase.
 
@@ -231,23 +224,31 @@ from all peer nodes to the command initiated node.
 
 ***New in 3.9***
 
-    gluster-georep-sshkey generate
+```console
+# gluster-georep-sshkey generate
+```
 
 This command adds extra prefix inside common_secret.pem.pub file to
 each pub keys to prevent running extra commands using this key, to
 disable that prefix,
 
-    gluster-georep-sshkey generate --no-prefix
+```console
+# gluster-georep-sshkey generate --no-prefix
+```
 
 ***Version 3.8 and below***
 
-    gluster system:: execute gsec_create
+```console
+# gluster system:: execute gsec_create
+```
 
 This command adds extra prefix inside common_secret.pem.pub file to
 each pub keys to prevent running extra commands using this key, to
 disable that prefix,
 
-    gluster system:: execute gsec_create container
+```console
+# gluster system:: execute gsec_create container
+```
 
 ## Creating the session
 Create a geo-rep session between master and slave volume using the
@@ -257,21 +258,29 @@ setup between them. The push-pem option actually uses the secret pem
 pub file created earlier and establishes geo-rep specific password
 less ssh between each node in master to each node of slave.
 
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> \
-        create [ssh-port <port>] push-pem|no-verify [force]
+```console
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> \
+    create [ssh-port <port>] push-pem|no-verify [force]
+```
 
 For example(Root user in Slave)
 
-    gluster volume geo-replication gv1 snode1::gv2 create push-pem
+```console
+# gluster volume geo-replication gv1 snode1::gv2 create push-pem
+```
 
 Non Root user,
 
-    gluster volume geo-replication gv1 geoaccount@snode1::gv2 create push-pem
+```console
+# gluster volume geo-replication gv1 geoaccount@snode1::gv2 create push-pem
+```
 
 If custom SSH port is configured in Slave nodes then,
 
-    gluster volume geo-replication gv1 snode1::gv2 create ssh-port 50022 push-pem
+```console
+# gluster volume geo-replication gv1 snode1::gv2 create ssh-port 50022 push-pem
+```
 
 If the total available size in slave volume is less than the total
 size of master, the command will throw error message. In such cases
@@ -289,12 +298,16 @@ slave side verifications are taken care of by the external agent, then
 Then use following command to create Geo-rep session with `no-verify`
 option.
 
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> create no-verify [force]
+```console
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> create no-verify [force]
+```
 
 For example,
 
-    gluster volume geo-replication gv1 snode1::gv2 create no-verify
+```console
+# gluster volume geo-replication gv1 snode1::gv2 create no-verify
+```
 
 In this case the master node rsa-key distribution to slave node does
 not happen and above mentioned slave verification is not performed and
@@ -304,8 +317,10 @@ these two things has to be taken care externaly.
 In case of non root user, run the following command as root in any one
 of Slave node.
 
-    /usr/libexec/glusterfs/set_geo_rep_pem_keys.sh <slave_user> \
-        <master_volume> <slave_volume>
+```console
+/usr/libexec/glusterfs/set_geo_rep_pem_keys.sh <slave_user> \
+    <master_volume> <slave_volume>
+```
 
 ## Configuration
 Configuration can be changed anytime after creating the session. After
@@ -314,23 +329,31 @@ restarted.
 
 To view all configured options of a session,
 
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> config [option]
+```console
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> config [option]
+```
 
 For Example,
 
-    gluster volume geo-replication gv1 snode1::gv2 config
-    gluster volume geo-replication gv1 snode1::gv2 config sync-jobs
+```console
+# gluster volume geo-replication gv1 snode1::gv2 config
+# gluster volume geo-replication gv1 snode1::gv2 config sync-jobs
+```
 
 To configure Gluster Geo-replication, use the following command at the
 Gluster command line
 
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> config [option]
+```console
+gluster volume geo-replication <master_volume> \
+   [<slave_user>@]<slave_host>::<slave_volume> config [option]
+```
 
 For example:
 
-    gluster volume geo-replication gv1 snode1::gv2 config sync-jobs 3
+```console
+# gluster volume geo-replication gv1 snode1::gv2 config sync-jobs 3
+```
 
 > **Note**: If Geo-rep is in between sync, restart due to configuration
 >  change may cause resyncing a few entries which are already synced.
@@ -352,9 +375,11 @@ file inside meta volume. Lock file name pattern will be different for
 each sub volume. If a worker acquire lock, then it will become Active
 else remain as Passive.
 
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> config
-        use-meta-volume true
+```console
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> config
+    use-meta-volume true
+```
 
 > **Note**: Meta Volume is shared replica 3 Gluster Volume. The name
 > of the meta-volume should be `gluster_shared_storage` and should be
@@ -378,13 +403,17 @@ The following table provides an overview of the configurable options for a geo-r
 
 Use the following command to start geo-replication session,
 
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> start [force]
+```console
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> start [force]
+```
 
 For example,
 
-    gluster volume geo-replication gv1 snode1::gv2 start
-    gluster volume geo-replication gv1 geoaccount@snode1::gv2 start
+```console
+# gluster volume geo-replication gv1 snode1::gv2 start
+# gluster volume geo-replication gv1 geoaccount@snode1::gv2 start
+```
 
 > **Note**
 >
@@ -395,46 +424,58 @@ For example,
 
 Use the following command to stop geo-replication sesion,
 
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> stop [force]
+```console
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> stop [force]
+```
 
 For example,
 
-    gluster volume geo-replication gv1 snode1::gv2 stop
-    gluster volume geo-replication gv1 geoaccount@snode1::gv2 stop
-
+```console
+# gluster volume geo-replication gv1 snode1::gv2 stop
+# gluster volume geo-replication gv1 geoaccount@snode1::gv2 stop
+```
 
 ## Status
 To check the status of all Geo-replication sessions in the Cluster
 
-    gluster volume geo-replication status
+```console
+# gluster volume geo-replication status
+```
 
 To check the status of one session,
 
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> status [detail]
+```console
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> status [detail]
+```
 
 Example,
 
-    gluster volume geo-replication gv1 snode1::gv2 status
-    gluster volume geo-replication gv1 snode1::gv2 status detail
-    gluster volume geo-replication gv1 geoaccount@snode1::gv2 status
-    gluster volume geo-replication gv1 geoaccount@snode1::gv2 status detail
+```console
+# gluster volume geo-replication gv1 snode1::gv2 status
+# gluster volume geo-replication gv1 snode1::gv2 status detail
+# gluster volume geo-replication gv1 geoaccount@snode1::gv2 status
+# gluster volume geo-replication gv1 geoaccount@snode1::gv2 status detail
+```
 
 Example Status Output
 
-    MASTER NODE    MASTER VOL    MASTER BRICK    SLAVE USER    SLAVE        SLAVE NODE    STATUS    CRAWL STATUS       LAST_SYNCED
-    -------------------------------------------------------------------------------------------------------------------------------------
-    mnode1         gv1           /bricks/b1      root          snode1::gv2  snode1        Active    Changelog Crawl    2016-10-12 23:07:13
-    mnode2         gv1           /bricks/b2      root          snode1::gv2  snode2        Active    Changelog Crawl    2016-10-12 23:07:13
+```console
+MASTER NODE    MASTER VOL    MASTER BRICK    SLAVE USER    SLAVE        SLAVE NODE    STATUS    CRAWL STATUS       LAST_SYNCED
+-------------------------------------------------------------------------------------------------------------------------------------
+mnode1         gv1           /bricks/b1      root          snode1::gv2  snode1        Active    Changelog Crawl    2016-10-12 23:07:13
+mnode2         gv1           /bricks/b2      root          snode1::gv2  snode2        Active    Changelog Crawl    2016-10-12 23:07:13
+```
 
 Example Status detail Output
 
-    MASTER NODE    MASTER VOL    MASTER BRICK    SLAVE USER    SLAVE        SLAVE NODE    STATUS    CRAWL STATUS       LAST_SYNCED            ENTRY    DATA    META    FAILURES    CHECKPOINT TIME    CHECKPOINT COMPLETED    CHECKPOINT COMPLETION TIME
-    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    mnode1         gv1           /bricks/b1      root          snode1::gv2  snode1        Active    Changelog Crawl    2016-10-12 23:07:13    0        0       0       0           N/A                N/A                     N/A
-    mnode2         gv1           /bricks/b2      root          snode1::gv2  snode2        Active    Changelog Crawl    2016-10-12 23:07:13    0        0       0       0           N/A                N/A                     N/A
-
+```console
+MASTER NODE    MASTER VOL    MASTER BRICK    SLAVE USER    SLAVE        SLAVE NODE    STATUS    CRAWL STATUS       LAST_SYNCED            ENTRY    DATA    META    FAILURES    CHECKPOINT TIME    CHECKPOINT COMPLETED    CHECKPOINT COMPLETION TIME
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+mnode1         gv1           /bricks/b1      root          snode1::gv2  snode1        Active    Changelog Crawl    2016-10-12 23:07:13    0        0       0       0           N/A                N/A                     N/A
+mnode2         gv1           /bricks/b2      root          snode1::gv2  snode2        Active    Changelog Crawl    2016-10-12 23:07:13    0        0       0       0           N/A                N/A                     N/A
+```
 
 The `STATUS` of the session could be one of the following,
 
@@ -473,12 +514,16 @@ The `CRAWL STATUS` can be one of the following:
 Established Geo-replication session can be deleted using the following
 command,
 
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> delete [force]
+```console
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> delete [force]
+```
 
 For example,
 
-    gluster volume geo-replication gv1 snode1::gv2 delete
+```console
+# gluster volume geo-replication gv1 snode1::gv2 delete
+```
 
 > Note: If the same session is created again then syncing will resume
 > from where it was stopped before deleting the session. If the
@@ -495,18 +540,24 @@ modified before the Checkpoint Time.
 
 Set the Checkpoint using,
 
-        gluster volume geo-replication <master_volume> \
-            [<slave_user>@]<slave_host>::<slave_volume> config checkpoint now
+```console
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> config checkpoint now
+```
 
 Example,
 
-    gluster volume geo-replication gv1 snode1::gv2 config checkpoint now
+```console
+# gluster volume geo-replication gv1 snode1::gv2 config checkpoint now
+```
 
 Touch the Master mount point to make sure Checkpoint completes even
 though no I/O happening in the Volume
 
-    mount -t glusterfs <masterhost>:<mastervol> /mnt
-    touch /mnt
+```console
+# mount -t glusterfs <masterhost>:<mastervol> /mnt
+# touch /mnt
+```
 
 Checkpoint status can be checked using Geo-rep status
 command. Following columns in status output gives more information
@@ -537,11 +588,11 @@ slave Volumes.
   name for snapshots)
 
         gluster snapshot create <snapname> <volname>
-    
+
     Example,
 
-        gluster snapshot create snap1 gv2
-        gluster snapshot create snap1 gv1
+        # gluster snapshot create snap1 gv2
+        # gluster snapshot create snap1 gv1
 
 - Resume Geo-replication session using,
 
@@ -552,12 +603,16 @@ If we want to continue Geo-rep session after snapshot restore, we need
 to restore both Master and Slave Volume and resume the Geo-replication
 session using force option
 
-    gluster snapshot restore <snapname>
-    gluster volume geo-replication <master_volume> \
-        [<slave_user>@]<slave_host>::<slave_volume> resume force
+```console
+gluster snapshot restore <snapname>
+gluster volume geo-replication <master_volume> \
+    [<slave_user>@]<slave_host>::<slave_volume> resume force
+```
 
 Example,
 
-    gluster snapshot restore snap1 # Slave Snap
-    gluster snapshot restore snap1 # Master Snap
-    gluster volume geo-replication gv1 snode1::gv2 resume force
+```console
+# gluster snapshot restore snap1 # Slave Snap
+# gluster snapshot restore snap1 # Master Snap
+# gluster volume geo-replication gv1 snode1::gv2 resume force
+```

--- a/docs/Administrator Guide/GlusterFS Coreutils.md
+++ b/docs/Administrator Guide/GlusterFS Coreutils.md
@@ -13,10 +13,15 @@ For now glusterfs-coreutils will be packaged only as rpm. Other package formats 
 ##### For fedora
 Use dnf/yum to install glusterfs-coreutils:
 
-    dnf install glusterfs-coreutils
+```console
+# dnf install glusterfs-coreutils
+```
+
 OR
 
-    yum install glusterfs-coreutils
+```console
+# yum install glusterfs-coreutils
+```
 
 ## Usage
 glusterfs-coreutils provides a set of basic utilities such as cat, cp, flock, ls, mkdir, rm, stat and tail that are implemented specifically using the GlusterFS API commonly known as libgfapi. These utilities can be used either inside a gluster remote
@@ -26,40 +31,60 @@ shell or as standalone commands with 'gf' prepended to their respective base nam
 ##### Invoke a new shell
 In order to enter into a gluster client-shell, type *gfcli* and press enter. You will now be presented with a similar prompt as shown below:
 
-    gfcli>
+```console
+# gfcli
+gfcli>
+```
 
 See the man page for *gfcli* for more options.
 ##### Connect to a gluster volume
 Now we need to connect as a client to some glusterfs volume which has already started. Use connect command to do so as follows:
 
-    gfcli> connect glfs://<SERVER-IP or HOSTNAME>/<VOLNAME>
+```console
+gfcli> connect glfs://<SERVER-IP or HOSTNAME>/<VOLNAME>
+```
 
 For example if you have a volume named vol on a server with hostname localhost the above command will take the following form:
 
-    gfcli> connect glfs://localhost/vol
+```console
+gfcli> connect glfs://localhost/vol
+```
 
 Make sure that you are successfully attached to a remote gluster volume by verifying the new prompt which should look like:
 
-    gfcli (<SERVER IP or HOSTNAME/<VOLNAME>)
+```console
+gfcli (<SERVER IP or HOSTNAME/<VOLNAME>)
+```
+
 ##### Try out your favorite utilities
 Please go through the man pages for different utilities and available options for each command. For example, *man gfcp* will display details on the usage of cp command outside or within a gluster-shell. Run different commands as follows:
 
-    gfcli (localhost/vol) ls .
-    gfcli (localhost/vol) stat .trashcan
+```console
+gfcli (localhost/vol) ls .
+gfcli (localhost/vol) stat .trashcan
+```
+
 ##### Terminate the client connection from the volume
 Use disconnect command to close the connection:
 
-    gfcli (localhost/vol) disconnect
-    gfcli>
+```console
+gfcli (localhost/vol) disconnect
+gfcli>
+```
+
 ##### Exit from shell
 Run quit from shell:
 
-    gfcli> quit
+```console
+gfcli> quit
+```
 
 #### Using standalone glusterfs coreutil commands
 As mentioned above glusterfs coreutils also provides standalone commands to perform the basic GNU coreutil functionalities. All those commands are prepended by 'gf'. Instead of invoking a gluster client-shell you can directly make use of these to establish and perform the operation in one shot. For example see the following sample usage of gfstat command:
 
-    gfstat glfs://localhost/vol/foo
+```console
+gfstat glfs://localhost/vol/foo
+```
 
 There is an exemption regarding flock coreutility which is not available as a standalone command for a reason described under 'Notes' section.
 

--- a/docs/Administrator Guide/Managing Snapshots.md
+++ b/docs/Administrator Guide/Managing Snapshots.md
@@ -1,11 +1,9 @@
-Managing GlusterFS Volume Snapshots
-==========================
+# Managing GlusterFS Volume Snapshots
 
 This section describes how to perform common GlusterFS volume snapshot
 management operations
 
-Pre-requisites
-=====================
+## Pre-requisites
 
 GlusterFS volume snapshot feature is based on thinly provisioned LVM snapshot.
 To make use of snapshot feature GlusterFS volume should fulfill following
@@ -20,8 +18,7 @@ Details of how to create thin volume can be found at the following link.
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Logical_Volume_Manager_Administration/LV.html#thinly_provisioned_volume_creation
 
 
-Few features of snapshot are:
-=============================
+## Few features of snapshot are:
 
 **Crash Consistency**
 
@@ -53,18 +50,14 @@ is not complete within that span then fops are unbarried. If unbarrier happens
 before the snapshot creation is complete then the snapshot creation operation
 fails. This to ensure that the snapshot is in a consistent state.
 
+## Snapshot Management
 
+### Snapshot creation
 
-Snapshot Management
-=====================
+```console
+gluster snapshot create <snapname> <volname> [no-timestamp] [description <description>] [force]
+```
 
-
-**Snapshot creation**
-
-Syntax :
-*gluster snapshot create <snapname\> <volname\> \[no-timestamp] \[description <description\>\] \[force\]*
-
-Details :
 Creates a snapshot of a GlusterFS volume. User can provide a snap-name and a
 description to identify the snap. The description cannot be more than 1024
 characters.
@@ -72,32 +65,28 @@ characters.
 Snapshot will be created by appending timestamp with user provided snap name.
 User can override this behaviour by giving no-timestamp flag.
 
-NOTE : To be able to take a snapshot, volume should be present and it
+**NOTE**: To be able to take a snapshot, volume should be present and it
 should be in started state.
 
------------------------------------------------------------------------------
+### Snapshot clone
 
-**Snapshot clone**
+```console
+gluster snapshot clone <clonename> <snapname>
+```
 
-Syntax :
-*gluster snapshot clone <clonename\> <snapname\>*
-
-Details :
 Creates a clone of a snapshot. Upon successful completion, a new GlusterFS
 volume will be created from snapshot. The clone will be a space efficient clone,
 i.e, the snapshot and the clone will share the backend disk.
 
-NOTE : To be able to take a clone from snapshot, snapshot should be present
+**NOTE**: To be able to take a clone from snapshot, snapshot should be present
 and it should be in activated state.
 
------------------------------------------------------------------------------
+### Restoring snaps
 
-**Restoring snaps**
+```console
+gluster snapshot restore <snapname>
+```
 
-Syntax :
-*gluster snapshot restore <snapname\>*
-
-Details :
 Restores an already taken snapshot of a GlusterFS volume.
 Snapshot restore is an offline activity therefore if the volume is
 online (in started state) then the restore operation will fail.
@@ -105,52 +94,44 @@ online (in started state) then the restore operation will fail.
 Once the snapshot is restored it will not be available in the
 list of snapshots.
 
----------------------------------------------------------------------------
+### Deleting snaps
 
-**Deleting snaps**
+```console
+gluster snapshot delete (all | <snapname> | volume <volname>)
+```
 
-Syntax :
-*gluster snapshot delete \(all | <snapname\> | volume <volname\>\)*
-
-Details :
 If snapname is specified then mentioned snapshot is deleted.
 If volname is specified then all snapshots belonging to that particular
 volume is deleted. If keyword *all* is used then all snapshots belonging
 to the system is deleted.
 
---------------------------------------------------------------------------
+### Listing of available snaps
 
-**Listing of available snaps**
+```console
+gluster snapshot list [volname]
+```
 
-Syntax:
-*gluster snapshot list \[volname\]*
-
-Details:
 Lists  all  snapshots  taken.
 If volname is provided, then only the snapshots belonging to
 that particular volume is listed.
 
--------------------------------------------------------------------------
+### Information of available snaps
 
-**Information of available snaps**
+```console
+gluster snapshot info [(snapname | volume <volname>)]
+```
 
-Syntax:
-*gluster snapshot info \[\(snapname | volume <volname\>\)\]*
-
-Details:
 This command gives information such as snapshot name, snapshot UUID,
 time at which snapshot was created, and it lists down the snap-volume-name,
 number of snapshots already taken and number of snapshots still available
 for that particular volume, and the state of the snapshot.
 
-------------------------------------------------------------------------
+### Status of snapshots
 
-**Status of snapshots**
+```console
+gluster snapshot status [(snapname | volume <volname>)]
+```
 
-Syntax:
-*gluster snapshot status \[\(snapname | volume <volname\>\)\]*
-
-Details:
 This  command  gives  status of the snapshot.
 The details included are snapshot brick path, volume group(LVM details),
 status of the snapshot bricks, PID of the bricks, data percentage  filled for
@@ -162,16 +143,14 @@ If volname  is specified then status of all snapshots belonging to that volume
 is displayed. If both snapname and volname is not specified then status of all
 the snapshots present in the system are displayed.
 
-------------------------------------------------------------------------
+### Configuring the snapshot behavior
 
-**Configuring the snapshot behavior**
+```console
+snapshot config [volname] ([snap-max-hard-limit <count>] [snap-max-soft-limit <percent>])
+                            | ([auto-delete <enable|disable>])
+                            | ([activate-on-create <enable|disable>])
+```
 
-Syntax:
-*snapshot config \[volname\] \(\[snap-max-hard-limit <count\>\] \[snap-max-soft-limit <percent>\]\)
-                            | \(\[auto-delete <enable|disable\>\]\)
-                            | \(\[activate-on-create <enable|disable\>\]\)*
-
-Details:
 Displays and sets the snapshot config values.
 
 snapshot  config without any keywords displays the snapshot config values of
@@ -197,114 +176,118 @@ Upon reaching the hard-limit, further snapshot creations will not be allowed.
 
 activate-on-create is disabled by default. If you enable activate-on-create,
 then further snapshot will be activated during the time of snapshot creation.
--------------------------------------------------------------------------
 
-**Activating a snapshot**
+### Activating a snapshot
 
-Syntax:
-*gluster snapshot activate <snapname\>*
+```console
+gluster snapshot activate <snapname>
+```
 
-Details:
 Activates the mentioned snapshot.
 
-Note : By default the snapshot will not be activated during snapshot creation.
+**Note**: By default the snapshot will not be activated during snapshot creation.
 
--------------------------------------------------------------------------
+### Deactivate a snapshot
 
-**Deactivate a snapshot**
+```console
+gluster snapshot deactivate <snapname>
+```
 
-Syntax:
-*gluster snapshot deactivate <snapname\>*
-
-Details:
 Deactivates the mentioned snapshot.
 
--------------------------------------------------------------------------
-
-**Accessing the snapshot**
+### Accessing the snapshot
 
 Snapshots can be accessed in 2 ways.
 
-1) Mounting the snapshot:
+1. Mounting the snapshot:
 
-The snapshot can be accessed via FUSE mount (only fuse). To do that it has to be
-mounted first. A snapshot can be mounted via fuse by below command
+    The snapshot can be accessed via FUSE mount (only fuse). To do that it has to be
+    mounted first. A snapshot can be mounted via fuse by below command
 
-*mount -t glusterfs <hostname>:/snaps/<snap-name>/<volume-name> <mount-path>*
+        mount -t glusterfs <hostname>:/snaps/<snap-name>/<volume-name> <mount-path>
 
-i.e. say "host1" is one of the peers. Let "vol" be the volume name and "my-snap"
-be the snapshot name. In this case a snapshot can be mounted via this command
+    i.e. say "host1" is one of the peers. Let "vol" be the volume name and "my-snap"
+    be the snapshot name. In this case a snapshot can be mounted via this command
 
-*mount -t glusterfs host1:/snaps/my-snap/vol /mnt/snapshot*
+        # mount -t glusterfs host1:/snaps/my-snap/vol /mnt/snapshot
 
 
-2) User serviceability:
+2. User serviceability:
 
-Apart from the above method of mounting the snapshot, a list of available
-snapshots and the contents of each snapshot can be viewed from any of the mount
-points accessing the glusterfs volume (either FUSE or NFS or SMB). For having
-user serviceable snapshots, it has to be enabled for a volume first. User
-serviceability can be enabled for a volume using the below command.
+    Apart from the above method of mounting the snapshot, a list of available
+    snapshots and the contents of each snapshot can be viewed from any of the mount
+    points accessing the glusterfs volume (either FUSE or NFS or SMB). For having
+    user serviceable snapshots, it has to be enabled for a volume first. User
+    serviceability can be enabled for a volume using the below command.
 
-*gluster volume set <volname> features.uss enable*
+        gluster volume set <volname> features.uss enable
 
-Once enabled, from any of the directory (including root of the filesystem) an
-access point will be created to the snapshot world. The access point is a hidden
-directory cding into which will make the user enter the snapshot world. By
-default the hidden directory is ".snaps". Once user serviceability is enabled,
-one will be able to cd into .snaps from any directory. Doing "ls" on that
-directory shows a list of directories which are nothing but the snapshots
-present for that volume. Say if there are 3 snapshots ("snap1", "snap2",
-"snap3"), then doing ls in .snaps directory will show those 3 names as the
-directory entries. They represent the state of the directory from which .snaps
-was entered, at different points in time.
+    Once enabled, from any of the directory (including root of the filesystem) an
+    access point will be created to the snapshot world. The access point is a hidden
+    directory cding into which will make the user enter the snapshot world. By
+    default the hidden directory is ".snaps". Once user serviceability is enabled,
+    one will be able to cd into .snaps from any directory. Doing "ls" on that
+    directory shows a list of directories which are nothing but the snapshots
+    present for that volume. Say if there are 3 snapshots ("snap1", "snap2",
+    "snap3"), then doing ls in .snaps directory will show those 3 names as the
+    directory entries. They represent the state of the directory from which .snaps
+    was entered, at different points in time.
 
-NOTE: The access to the snapshots are read-only. The snapshot needs to be 
-activated for it to be accessible inside .snaps directory.
+    **NOTE**: The access to the snapshots are read-only. The snapshot needs to be 
+    activated for it to be accessible inside .snaps directory.
 
-Also, the name of the hidden directory (or the access point to the snapshot
-world) can be changed using the below command.
+    Also, the name of the hidden directory (or the access point to the snapshot
+    world) can be changed using the below command.
 
-*gluster volume set <volname> snapshot-directory <new-name>*
+        gluster volume set <volname> snapshot-directory <new-name>
 
-3) Accessing from windows:
-The glusterfs volumes can be made accessible by windows via samba. (the
-glusterfs plugin for samba helps achieve this, without having to re-export
-a fuse mounted glusterfs volume). The snapshots of a glusterfs volume can
-also be viewed in the windows explorer.
+3. Accessing from windows:
 
-There are 2 ways:
-* Give the path of the entry point directory
-(\\<hostname>\<samba-share>\<directory>\<entry-point path>) in the run command
-window
-* Go to the samba share via windows explorer. Make hidden files and folders
-visible so that in the root of the samba share a folder icon for the entry point
-can be seen.
+    The glusterfs volumes can be made accessible by windows via samba. (the
+    glusterfs plugin for samba helps achieve this, without having to re-export
+    a fuse mounted glusterfs volume). The snapshots of a glusterfs volume can
+    also be viewed in the windows explorer.
 
-NOTE: From the explorer, snapshot world can be entered via entry point only from
+    There are 2 ways:
+    * Give the path of the entry point directory
+      (`<hostname><samba-share><directory><entry-point path>`) in the run command
+      window
+
+    * Go to the samba share via windows explorer. Make hidden files and folders
+      visible so that in the root of the samba share a folder icon for the entry point
+      can be seen.
+
+**NOTE**: From the explorer, snapshot world can be entered via entry point only from
 the root of the samba share. If snapshots have to be seen from subfolders, then
 the path should be provided in the run command window.
 
 For snapshots to be accessible from windows, below 2 options can be used.
-A) The glusterfs plugin for samba should give the option "snapdir-entry-path"
-while starting. The option is an indication to glusterfs, that samba is loading
-it and the value of the option should be the path that is being used as the
-share for windows.
-Ex: Say, there is a glusterfs volume and a directory called "export" from the
-root of the volume is being used as the samba share, then samba has to load
-glusterfs with this option as well.
 
-        ret = glfs_set_xlator_option(fs, "*-snapview-client",
-                                     "snapdir-entry-path", "/export");
-The xlator option "snapdir-entry-path" is not exposed via volume set options,
-cannot be changed from CLI. Its an option that has to be provided at the time of
-mounting glusterfs or when samba loads glusterfs.
-B) The accessibility of snapshots via root of the samba share from windows
-is configurable. By default it is turned off. It is a volume set option which can
-be changed via CLI.
+1. The glusterfs plugin for samba should give the option "snapdir-entry-path"
+   while starting. The option is an indication to glusterfs, that samba is loading
+   it and the value of the option should be the path that is being used as the
+   share for windows.
 
-gluster volume set <volname> features.show-snapshot-directory "on/off". By
-default it is off.
+    Ex: Say, there is a glusterfs volume and a directory called "export" from the
+    root of the volume is being used as the samba share, then samba has to load
+    glusterfs with this option as well.
+
+        ret = glfs_set_xlator_option(
+                fs,
+                "*-snapview-client",
+                "snapdir-entry-path", "/export"
+        );
+
+    The xlator option "snapdir-entry-path" is not exposed via volume set options,
+    cannot be changed from CLI. Its an option that has to be provided at the time of
+    mounting glusterfs or when samba loads glusterfs.
+
+2. The accessibility of snapshots via root of the samba share from windows
+   is configurable. By default it is turned off. It is a volume set option which can
+   be changed via CLI.
+
+    `gluster volume set <volname> features.show-snapshot-directory <on/off>`. By
+    default it is off.
 
 Only when both the above options have been provided (i.e snapdir-entry-path
 contains a valid unix path that is exported and show-snapshot-directory option
@@ -313,6 +296,3 @@ is set to true), snapshots can accessed via windows explorer.
 If only 1st option (i.e. snapdir-entry-path) is set via samba and 2nd option
 (i.e. show-snapshot-directory) is off, then snapshots can be accessed from
 windows via the run command window, but not via the explorer.
-
-
---------------------------------------------------------------------------------------

--- a/docs/Administrator Guide/Mandatory Locks.md
+++ b/docs/Administrator Guide/Mandatory Locks.md
@@ -7,23 +7,22 @@ By default, mandatory locking will be disabled for a volume and a volume set opt
 
 ## Volume Option
 
-* ***gluster volume set &lt;VOLNAME> locks.mandatory-locking &lt;off / file / forced / optimal>***
+```console
+gluster volume set <VOLNAME> locks.mandatory-locking <off / file / forced / optimal>
+```
 
-     **off**      - Disable mandatory locking for specified volume.
+**off**      - Disable mandatory locking for specified volume.<br/>
+**file**     - Enable Linux kernel style mandatory locking semantics with the help of mode bits (not well tested)<br/>
+**forced**   - Check for conflicting byte range locks for every data modifying operation in a volume<br/>
+**optimal**  - Combinational mode where POSIX clients can live with their advisory lock semantics which will still honour the mandatory locks acquired by other clients like SMB.
 
-     **file**     - Enable Linux kernel style mandatory locking semantics with the help of mode bits (not well tested)
+**Note**:- Please refer the design doc for more information on these key values.
 
-     **forced**   - Check for conflicting byte range locks for every data modifying operation in a volume
-
-     **optimal**  - Combinational mode where POSIX clients can live with their advisory lock semantics which will still honour the mandatory locks acquired by other clients like SMB.
-
-Note:- Please refer the design doc for more information on these key values.
-
-##### Points to be remembered
+#### Points to be remembered
 * Valid key values available with mandatory-locking volume set option are taken into effect only after a subsequent start/restart of the volume.
 * Due to some outstanding issues, it is recommended to turn off the performance translators in order to have the complete functionality of mandatory-locks when volume is configured in any one of the above described mandatory-locking modes. Please see the 'Known issue' section below for more details.
 
-##### Known issues
+#### Known issues
 * Since the whole logic of mandatory-locks are implemented within the locks translator loaded at the server side, early success returned to fops like open, read, write to upper/application layer by performance translators residing at the client side will impact the intended functionality of mandatory-locks. One such issue is being tracked in the following bugzilla report:
 
     <https://bugzilla.redhat.com/show_bug.cgi?id=1194546>

--- a/docs/Administrator Guide/Start Stop Daemon.md
+++ b/docs/Administrator Guide/Start Stop Daemon.md
@@ -19,13 +19,17 @@ following ways:
 
 This section describes how to start and stop glusterd manually
 
--   To start glusterd manually, enter the following command:
+- To start glusterd manually, enter the following command:
 
-    `# /etc/init.d/glusterd start `
+```console
+# /etc/init.d/glusterd start
+```
 
 -   To stop glusterd manually, enter the following command:
 
-    `# /etc/init.d/glusterd stop`
+```console
+# /etc/init.d/glusterd stop
+```
 
 <a name="auto"></a>
 ## Starting glusterd Automatically
@@ -39,7 +43,9 @@ To configure Red Hat-based systems to automatically start the glusterd
 service every time the system boots, enter the following from the
 command line:
 
-`# chkconfig glusterd on `
+```console
+# chkconfig glusterd on
+```
 
 ### Debian and derivatives like Ubuntu
 
@@ -47,7 +53,9 @@ To configure Debian-based systems to automatically start the glusterd
 service every time the system boots, enter the following from the
 command line:
 
-`# update-rc.d glusterd defaults`
+```console
+# update-rc.d glusterd defaults
+```
 
 ### Systems Other than Red Hat and Debian
 
@@ -55,4 +63,6 @@ To configure systems other than Red Hat or Debian to automatically start
 the glusterd service every time the system boots, enter the following
 entry to the*/etc/rc.local* file:
 
-`# echo "glusterd" >> /etc/rc.local `
+```console
+# echo "glusterd" >> /etc/rc.local
+```

--- a/docs/Administrator Guide/Storage Pools.md
+++ b/docs/Administrator Guide/Storage Pools.md
@@ -17,7 +17,6 @@ each server belongs to a storage pool consisting of only that server.
 -  [Removing Servers](#removing-servers)
 
 
-
 **Before you start**:
 
 - The servers used to create the storage pool must be resolvable by hostname.
@@ -35,92 +34,100 @@ and server3.
 
 To add a server to a TSP, peer probe it from a server already in the pool.
 
-        # gluster peer probe <server>
+```console
+# gluster peer probe <server>
+```
 
 For example, to add a new server4 to the cluster described above, probe it from one of the other servers:
 
-        server1#  gluster peer probe server4
-        Probe successful
+```console
+server1#  gluster peer probe server4
+Probe successful
+```
 
 Verify the peer status from the first server (server1):
 
-        server1# gluster peer status
-        Number of Peers: 3
+```console
+server1# gluster peer status
+Number of Peers: 3
 
-        Hostname: server2
-        Uuid: 5e987bda-16dd-43c2-835b-08b7d55e94e5
-        State: Peer in Cluster (Connected)
+Hostname: server2
+Uuid: 5e987bda-16dd-43c2-835b-08b7d55e94e5
+State: Peer in Cluster (Connected)
 
-        Hostname: server3
-        Uuid: 1e0ca3aa-9ef7-4f66-8f15-cbc348f29ff7
-        State: Peer in Cluster (Connected)
+Hostname: server3
+Uuid: 1e0ca3aa-9ef7-4f66-8f15-cbc348f29ff7
+State: Peer in Cluster (Connected)
 
-        Hostname: server4
-        Uuid: 3e0cabaa-9df7-4f66-8e5d-cbc348f29ff7
-        State: Peer in Cluster (Connected)
-
-
+Hostname: server4
+Uuid: 3e0cabaa-9df7-4f66-8e5d-cbc348f29ff7
+State: Peer in Cluster (Connected)
+```
 
 <a name="listing-servers"></a>
 ### Listing Servers
 
 To list all nodes in the TSP:
 
-        server1# gluster pool list
-        UUID                                    Hostname        State
-        d18d36c5-533a-4541-ac92-c471241d5418    localhost       Connected
-        5e987bda-16dd-43c2-835b-08b7d55e94e5    server2         Connected
-        1e0ca3aa-9ef7-4f66-8f15-cbc348f29ff7    server3         Connected
-        3e0cabaa-9df7-4f66-8e5d-cbc348f29ff7    server4         Connected
-
-
+```console
+server1# gluster pool list
+UUID                                    Hostname        State
+d18d36c5-533a-4541-ac92-c471241d5418    localhost       Connected
+5e987bda-16dd-43c2-835b-08b7d55e94e5    server2         Connected
+1e0ca3aa-9ef7-4f66-8f15-cbc348f29ff7    server3         Connected
+3e0cabaa-9df7-4f66-8e5d-cbc348f29ff7    server4         Connected
+```
 
 <a name="peer-status"></a>
 ### Viewing Peer Status
 
 To view the status of the peers in the TSP:
 
-        server1# gluster peer status
-        Number of Peers: 3
+```console
+server1# gluster peer status
+Number of Peers: 3
 
-        Hostname: server2
-        Uuid: 5e987bda-16dd-43c2-835b-08b7d55e94e5
-        State: Peer in Cluster (Connected)
+Hostname: server2
+Uuid: 5e987bda-16dd-43c2-835b-08b7d55e94e5
+State: Peer in Cluster (Connected)
 
-        Hostname: server3
-        Uuid: 1e0ca3aa-9ef7-4f66-8f15-cbc348f29ff7
-        State: Peer in Cluster (Connected)
+Hostname: server3
+Uuid: 1e0ca3aa-9ef7-4f66-8f15-cbc348f29ff7
+State: Peer in Cluster (Connected)
 
-        Hostname: server4
-        Uuid: 3e0cabaa-9df7-4f66-8e5d-cbc348f29ff7
-        State: Peer in Cluster (Connected)
-
-
+Hostname: server4
+Uuid: 3e0cabaa-9df7-4f66-8e5d-cbc348f29ff7
+State: Peer in Cluster (Connected)
+```
 
 <a name="removing-servers"></a>
 ### Removing Servers
 
 To remove a server from the TSP, run the following command from another server in the pool:
 
-        # gluster peer detach <server>
+```console
+# gluster peer detach <server>
+```
 
 For example, to remove server4 from the trusted storage pool:
 
-        server1# gluster peer detach server4
-        Detach successful
-
+```console
+server1# gluster peer detach server4
+Detach successful
+```
 
 Verify the peer status:
 
-        server1# gluster peer status
-        Number of Peers: 2
+```console
+server1# gluster peer status
+Number of Peers: 2
 
-        Hostname: server2
-        Uuid: 5e987bda-16dd-43c2-835b-08b7d55e94e5
-        State: Peer in Cluster (Connected)
+Hostname: server2
+Uuid: 5e987bda-16dd-43c2-835b-08b7d55e94e5
+State: Peer in Cluster (Connected)
 
-        Hostname: server3
-        Uuid: 1e0ca3aa-9ef7-4f66-8f15-cbc348f29ff7
-        State: Peer in Cluster (Connected)
-
+Hostname: server3
+Uuid: 1e0ca3aa-9ef7-4f66-8f15-cbc348f29ff7
+State: Peer in Cluster (Connected)
+```
 

--- a/docs/Administrator Guide/Trash.md
+++ b/docs/Administrator Guide/Trash.md
@@ -7,23 +7,23 @@ Apart from the primary use-case of accessing files deleted or truncated by user 
 
 ## Volume Options
 
-* ***gluster volume set &lt;VOLNAME> features.trash &lt;on / off>***
+* ***`gluster volume set <VOLNAME> features.trash <on/off>`***
 
     This command can be used to enable trash translator in a volume. If set to on, trash directory will be created in every brick inside the volume during volume start command. By default translator is loaded during volume start but remains non-functional. Disabling trash with the help of this option will not remove the trash directory or even its contents from the volume.
 
-* ***gluster volume set &lt;VOLNAME> features.trash-dir &lt;name>***
+* ***`gluster volume set <VOLNAME> features.trash-dir <name>`***
 
     This command is used to reconfigure the trash directory to a user specified name. The argument is a valid directory name. Directory will be created inside every brick under this name. If not specified by the user, the trash translator will create the trash directory with the default name “.trashcan”. This can be used only when trash-translator is on.
 
-* ***gluster volume set &lt;VOLNAME> features.trash-max-filesize &lt;size>***
+* ***`gluster volume set <VOLNAME> features.trash-max-filesize <size>`***
 
     This command can be used to filter files entering trash directory based on their size. Files above trash_max_filesize are deleted/truncated directly.Value for size may be followed by multiplicative suffixes as KB(=1024 bytes), MB(=1024\*1024 bytes) and GB(=1024\*1024\*1024 bytes). Default size is set to 5MB. Considering the fact that trash directory is consuming the glusterfs volume space, trash feature is implemented to function in such a way that it directly deletes/truncates files with size > 1GB even if this option is set to some value greater than 1GB.
 
-* ***gluster volume set &lt;VOLNAME> features.trash-eliminate-path &lt;path1> [ , &lt;path2> , . . . ]***
+* ***`gluster volume set <VOLNAME> features.trash-eliminate-path <path1> [ , <path2> , . . . ]`***
 
     This command can be used to set the eliminate pattern for the trash translator. Files residing under this pattern will not be moved to trash directory during deletion/truncation. Path must be a valid one present in volume.
 
-* ***gluster volume set &lt;VOLNAME> features.trash-internal-op &lt;on / off>***
+* ***`gluster volume set <VOLNAME> features.trash-internal-op <on/off>`***
 
     This command can be used to enable trash for internal operations like self-heal and re-balance. By default set to off.
 
@@ -60,19 +60,21 @@ We can find the deleted file inside the trash directory with timestamp appending
 
 For example,
 
-        [root@rh-host ~]# mount -t glusterfs rh-host:/test /mnt/test
-        [root@rh-host ~]# mkdir /mnt/test/abc
-        [root@rh-host ~]# touch /mnt/test/abc/file
-        [root@rh-host ~]# rm /mnt/test/abc/file
-        remove regular empty file ‘/mnt/test/abc/file’? y
-        [root@rh-host ~]# ls /mnt/test/abc
-        [root@rh-host ~]#
-        [root@rh-host ~]# ls /mnt/test/.trashcan/abc/
-        file2014-08-21_123400
+```console
+# mount -t glusterfs rh-host:/test /mnt/test
+# mkdir /mnt/test/abc
+# touch /mnt/test/abc/file
+# rm /mnt/test/abc/file
+remove regular empty file ‘/mnt/test/abc/file’? y
+# ls /mnt/test/abc
+#
+# ls /mnt/test/.trashcan/abc/
+file2014-08-21_123400
+```
 
-##### Points to be remembered
+#### Points to be remembered
 * As soon as the volume is started, trash directory will be created inside the volume and will be visible through mount. Disabling trash will not have any impact on its visibilty from the mount.
 * Even though deletion of trash-directory is not permitted, currently residing trash contents will be removed on issuing delete on it and only an empty trash-directory exists.
 
-##### Known issue
+#### Known issue
 Since trash translator resides on the server side higher translator like AFR, DHT are unaware of rename and truncate operations being done by this translator which eventually moves the files to trash directory. Unless and until a complete-path-based lookup comes on trashed files, those may not be visible from the mount.

--- a/docs/CLI-Reference/cli-main.md
+++ b/docs/CLI-Reference/cli-main.md
@@ -12,27 +12,33 @@ The gluster CLI syntax is `gluster <command>`.
 
 To run a command directly:
 
-	# gluster <command>
+```console
+# gluster <command>
+```
 
 For example, to view the status of all peers:
 
-	# gluster peer status
+```console
+# gluster peer status
+```
 
 To run a command in interactive mode, start a gluster shell by typing:
 
-	# gluster
+```console
+# gluster
+```
 
 This will open a gluster command prompt. You now run the command at the prompt.
 
-	gluster> <command>
+```console
+gluster> <command>
+```
 
 For example, to view the status of all peers,
 
-	gluster> peer status
-
-   
-
-
+```console
+gluster> peer status
+```
 
 #### Peer Commands
 
@@ -45,9 +51,6 @@ The peer commands are used to manage the Trusted Server Pool (TSP).
 | peer detach     | peer detach _server_   | Remove _server_ from the TSP |
 | peer status     | peer status            | Display the status of all nodes in the TSP |
 | pool list       | pool list              | List all nodes in the TSP |
-
-
-
 
 #### Volume Commands
 
@@ -69,7 +72,3 @@ The volume commands are used to setup and manage Gluster volumes.
 | volume delete        | volume delete _volname_    | Delete _volname_ |
 
 For additional detail of all the available CLI commands, please refer to `man gluster` output.
-
-
-
-

--- a/docs/Developer-guide/Building-GlusterFS.md
+++ b/docs/Developer-guide/Building-GlusterFS.md
@@ -32,21 +32,41 @@ The following packages are required for building GlusterFS,
 The following dnf command installs all the build requirements for
 Fedora,
 
-		# dnf install automake autoconf libtool flex bison openssl-devel libxml2-devel python-devel libaio-devel libibverbs-devel librdmacm-devel readline-devel lvm2-devel glib2-devel userspace-rcu-devel libcmocka-devel libacl-devel sqlite-devel fuse-devel redhat-rpm-config rpcgen libtirpc-devel make
+```console
+# dnf install automake autoconf libtool flex bison openssl-devel  \
+    libxml2-devel python-devel libaio-devel libibverbs-devel      \
+    librdmacm-devel readline-devel lvm2-devel glib2-devel         \
+    userspace-rcu-devel libcmocka-devel libacl-devel sqlite-devel \
+    fuse-devel redhat-rpm-config rpcgen libtirpc-devel make
+```
 
 ### Ubuntu
 
 The following apt-get command will install all the build requirements on
 Ubuntu,
 
-		$ sudo apt-get install make automake autoconf libtool flex bison pkg-config libssl-dev libxml2-dev python-dev libaio-dev libibverbs-dev librdmacm-dev libreadline-dev liblvm2-dev libglib2.0-dev liburcu-dev libcmocka-dev libsqlite3-dev libacl1-dev
+```console
+# sudo apt-get install make automake autoconf libtool flex bison  \
+    pkg-config libssl-dev libxml2-dev python-dev libaio-dev       \
+    libibverbs-dev librdmacm-dev libreadline-dev liblvm2-dev      \
+    libglib2.0-dev liburcu-dev libcmocka-dev libsqlite3-dev       \
+    libacl1-dev
+```
 
 ### CentOS / Enterprise Linux
 
 The following yum command installs the build requirements for CentOS / Enterprise Linux,
 
-		# yum install autoconf automake bison cmockery2-devel dos2unix flex fuse-devel glib2-devel libacl-devel libaio-devel libattr-devel libcurl-devel libibverbs-devel librdmacm-devel libtirpc-devel libtool libxml2-devel lvm2-devel make openssl-devel pkgconfig pyliblzma python-devel python-eventlet python-netifaces python-paste-deploy python-simplejson python-sphinx python-webob pyxattr readline-devel rpm-build sqlite-devel systemtap-sdt-devel tar userspace-rcu-devel
-
+```console
+# yum install autoconf automake bison cmockery2-devel dos2unix flex   \
+    fuse-devel glib2-devel libacl-devel libaio-devel libattr-devel    \
+    libcurl-devel libibverbs-devel librdmacm-devel libtirpc-devel     \
+    libtool libxml2-devel lvm2-devel make openssl-devel pkgconfig     \
+    pyliblzma python-devel python-eventlet python-netifaces           \
+    python-paste-deploy python-simplejson python-sphinx python-webob  \
+    pyxattr readline-devel rpm-build sqlite-devel systemtap-sdt-devel \
+    tar userspace-rcu-devel
+```
              
 Building from Source
 --------------------
@@ -63,77 +83,94 @@ process.
 
 Run autogen to generate the configure script.
 
-		$ ./autogen.sh
+```console
+# ./autogen.sh
+```
 
 Once autogen completes successfully a configure script is generated. Run
 the configure script to generate the makefiles.
 
-		$ ./configure
-		
+```console
+# ./configure
+```
+
 For CentOS, use:
 
-		$ ./configure --without-libtirpc
+```console
+# ./configure --without-libtirpc
+```
 
 If the above build requirements have been installed, running the
 configure script should give the below configure summary,
 
-		GlusterFS configure summary
-		===========================
-		FUSE client          : yes
-		Infiniband verbs     : yes
-		epoll IO multiplex   : yes
-		argp-standalone      : no
-		fusermount           : yes
-		readline             : yes
-		georeplication       : yes
-		Linux-AIO            : yes
-		Enable Debug         : no
-		Block Device xlator  : yes
-		glupy                : yes
-		Use syslog           : yes
-		XML output           : yes
-		Encryption xlator    : yes
-		Unit Tests	     : no
-		Track priv ports     : yes
-		POSIX ACLs           : yes
-		Data Classification  : yes
-		SELinux features     : yes
-		firewalld-config     : no
-		Experimental xlators : yes
-		Events		     : yes
-		EC dynamic support   : x64 sse avx
-		Use memory pools     : yes
-		Nanosecond m/atimes  : yes
-		Legacy gNFS server   : no
+```console
+GlusterFS configure summary
+===========================
+FUSE client          : yes
+Infiniband verbs     : yes
+epoll IO multiplex   : yes
+argp-standalone      : no
+fusermount           : yes
+readline             : yes
+georeplication       : yes
+Linux-AIO            : yes
+Enable Debug         : no
+Block Device xlator  : yes
+glupy                : yes
+Use syslog           : yes
+XML output           : yes
+Encryption xlator    : yes
+Unit Tests		 : no
+Track priv ports	 : yes
+POSIX ACLs			 : yes
+Data Classification	 : yes
+SELinux features	 : yes
+firewalld-config	 : no
+Experimental xlators : yes
+Events			 : yes
+EC dynamic support	 : x64 sse avx
+Use memory pools	 : yes
+Nanosecond m/atimes	 : yes
+Legacy gNFS server	 : no
+```
 
 During development it is good to enable a debug build. To do this run
 configure with a '--enable-debug' flag.
 
-		$ ./configure --enable-debug
+```console
+# ./configure --enable-debug
+```
 
 Further configuration flags can be found by running configure with a
 '--help' flag,
 
-		$ ./configure --help
-		
+```console
+# ./configure --help
+```
+
 Please note to enable gNFS use the following flag
 
-		$ ./configure --enable-gnfs
+```console
+# ./configure --enable-gnfs
+```
 
 If you are looking at contributing by fixing some of the memory issues,
 use `--enable-asan` option
 
-    $ ./configure --enable-asan
+```console
+# ./configure --enable-asan
+```
 
 The above option will build with `-fsanitize=address -fno-omit-frame-pointer`
 options and uses the libasan.so shared library, so that needs to be available.
-
 
 ### Building
 
 Once configured, GlusterFS can be built with a simple make command.
 
-		$ make
+```console
+# make
+```
 
 To speed up the build process on a multicore machine, add a '-jN' flag,
 where N is the number of parallel jobs.
@@ -145,7 +182,9 @@ installed into '/usr/local' prefix. To change the install prefix, give
 the appropriate option to configure. If installing into the default
 prefix, you might need to use 'sudo' or 'su -c' to install.
 
-		$ sudo make install
+```console
+# sudo make install
+```
 
 NOTE: glusterfs can be installed on any target path. However, the
 `mount.glusterfs` script has to be in `/sbin/mount.glusterfs` for
@@ -164,7 +203,9 @@ A source install will generally not install any init scripts. So you
 will need to start glusterd manually. To manually start glusterd just
 run,
 
-		# glusterd
+```console
+# glusterd
+```
 
 This will start glusterd and fork it into the background as a daemon
 process. You now run 'gluster' commands and make use of GlusterFS.
@@ -179,8 +220,10 @@ get the source and do the configuration steps as shown in the 'Building
 from Source' section. After the configuration step, run the following
 steps to build RPMs,
 
-		$ cd extras/LinuxRPM
-		$ make glusterrpms
+```console
+# cd extras/LinuxRPM
+# make glusterrpms
+```
 
 This will create rpms from the source in 'extras/LinuxRPM'. *(Note: You
 will need to install the rpmbuild requirements including rpmbuild and

--- a/docs/Developer-guide/Development-Workflow.md
+++ b/docs/Developer-guide/Development-Workflow.md
@@ -86,7 +86,9 @@ In Gerrit settings, watch the 'glusterfs' project. Tick on all the three
 Set up a filter rule in your mail client to tag or classify mails with
 the header
 
-        List-Id: <gerrit-glusterfs.review.gluster.org>
+```text
+List-Id: <gerrit-glusterfs.review.gluster.org>
+```
 
 as mails originating from the review system.
 
@@ -101,7 +103,9 @@ review/merge.
 Get yourself a working tree by cloning the development repository from
 Gerrit
 
-        sh$ git clone ssh://[username)@]git.gluster.org/glusterfs.git glusterfs
+```console
+git clone ssh://[username)@]git.gluster.org/glusterfs.git glusterfs
+```
 
 Branching policy
 ----------------
@@ -133,9 +137,11 @@ created from the upstream branch to which you intend to submit the
 change. If you are submitting changes to master branch, first create a
 local task branch like this -
 
-        sh$ git checkout master
-        sh$ git branch bug-XYZ && git checkout bug-XYZ
-        ... <hack, commit>
+```console
+# git checkout master
+# git branch bug-XYZ && git checkout bug-XYZ
+... <hack, commit>
+```
 
 Building
 --------
@@ -150,14 +156,18 @@ refer : [Building GlusterFS](./Building-GlusterFS.md)**
 Once the required packages are installed for your appropiate system,
 generate the build configuration:
 
-        sh$ ./autogen.sh
-        sh$ ./configure --enable-fusermount
+```console
+# ./autogen.sh
+# ./configure --enable-fusermount
+```
 
 ### Build and install
 
 #### GlusterFS
 
- sh$ make install
+```console
+# make install
+```
 
 Commit policy
 -------------
@@ -225,7 +235,9 @@ After doing the local commit, it is time to submit the code for review.
 There is a script available inside glusterfs.git called rfc.sh. You can
 submit your changes for review by simply executing
 
-        sh$ ./rfc.sh
+```console
+# ./rfc.sh
+```
 
 This script does the following:
 
@@ -294,8 +306,9 @@ changes in code, you can mark each of the inline comment as 'done'
 (optional). After all the changes to your local files, amend the
 previous commit with these changes with -
 
-        sh$ git commit -a --amend
-
+```console
+# git commit -a --amend
+```
 Push the amended commit by executing rfc.sh. If your previous push was
 an "rfc" push (i.e, without a Bug Id) you will be prompted for a Bug Id
 again. You can re-push an rfc change without any other code change too
@@ -337,8 +350,9 @@ necessary condition for merge along with code review points.
 
 To run all regession tests locally, run below script from glusterfs root directory.
 
-  sh$ ./run-tests.sh
-
+```console
+# ./run-tests.sh
+```
 
 Submission Qualifiers
 ---------------------
@@ -357,11 +371,11 @@ Submission Disqualifiers
 
 There are three types of "negative votes".
 
--1 Verified
+-1 Verified
 
--1 Code-Review ("I would prefer that you didn't submit this")
+-1 Code-Review ("I would prefer that you didn't submit this")
 
--2 Code-Review ("Do not submit")
+-2 Code-Review ("Do not submit")
 
 The implication and scope of each of the three are different. They
 behave differently as changes are resubmitted as new patchsets.

--- a/docs/Developer-guide/Fixing-issues-reported-by-tools-for-static-code-analysis.md
+++ b/docs/Developer-guide/Fixing-issues-reported-by-tools-for-static-code-analysis.md
@@ -38,15 +38,15 @@ Cppcheck is available in Fedora and EL's EPEL repo
 
 -   Install Cppcheck
 
-        dnf install cppcheck
+        # dnf install cppcheck
 
 -   Clone GlusterFS code
 
-        git clone https://github.com/gluster/glusterfs
+        # git clone https://github.com/gluster/glusterfs
 
 -   Run Cpp check
 
-        cppcheck glusterfs/ 2>cppcheck.log
+        # cppcheck glusterfs/ 2>cppcheck.log
 
 
 ### Daily Runs

--- a/docs/Developer-guide/Simplified-Development-Workflow.md
+++ b/docs/Developer-guide/Simplified-Development-Workflow.md
@@ -25,13 +25,17 @@ distribution specific package manger to install git. After installation
 configure git. At the minimum, set a git user email. To set the email
 do,
 
-		$ git config --global user.name "Name"
-		$ git config --global user.email <email address>
+```console
+git config --global user.name <name>
+git config --global user.email <email address>
+```
 
 You should also generate an ssh key pair if you haven't already done it.
 To generate a key pair do,
 
-		$ ssh-keygen
+```console
+# ssh-keygen
+```
 
 and follow the instructions.
 
@@ -53,11 +57,15 @@ email you configured for git.
 
 Git clone the GlusterFS source using
 
-		<ssh://><username>@review.gluster.org/glusterfs.git
+```console
+<ssh://><username>@review.gluster.org/glusterfs.git
+```
 
 (replace <username> with your gerrit username).
 
-		$ git clone (ssh://)<username> @review.gluster.org/glusterfs.git
+```console
+git clone (ssh://)<username> @review.gluster.org/glusterfs.git
+```
 
 This will clone the GlusterFS source into a subdirectory named glusterfs
 with the master branch checked out.
@@ -82,18 +90,24 @@ can be found at
 [Development Work Flow - Branching\_policy](./Development-Workflow.md#branching-policy).
 For example if you want to develop on the master branch,
 
-		$ git checkout master
-		$ git pull
+```console
+# git checkout master
+# git pull
+```
 
 Now, create a new branch from master and switch to the new branch. It is
 recommended to have descriptive branch names. Do,
 
-		$ git branch <descriptive-branch-name>
-		$ git checkout <descriptive-branch-name>
+```console
+git branch <descriptive-branch-name>
+git checkout <descriptive-branch-name>
+```
 
 or,
 
-		$ git checkout -b <descriptive-branch-name>
+```console
+git checkout -b <descriptive-branch-name>
+```
 
 to do both in one command.
 
@@ -120,8 +134,10 @@ you haven't broken anything. The regression test suite requires a
 working GlusterFS installation and needs to be run as root. To run the
 regression test suite, do
 
-		# make install
-		# ./run-tests.sh
+```console
+# make install
+# ./run-tests.sh
+```
 
 ### Commit your changes
 
@@ -129,12 +145,16 @@ If you haven't broken anything, you can now commit your changes. First
 identify the files that you modified/added/deleted using git-status and
 stage these files.
 
-		$ git status
-		$ git add <list of modified files>
+```console
+git status
+git add <list of modified files>
+```
 
 Now, commit these changes using
 
-		$ git commit -s
+```console
+# git commit -s
+```
 
 Provide a meaningful commit message. The commit message policy is
 described at
@@ -149,7 +169,9 @@ to reject patches which are not signed-off.
 
 To submit your change for review, run the rfc.sh script,
 
-		$ ./rfc.sh
+```console
+# ./rfc.sh
+```
 
 The script will ask you to enter a bugzilla bug id. Every change
 submitted to GlusterFS needs a reference ID to be accepted. If you do
@@ -211,7 +233,9 @@ review comments. Build and test to see if the new changes are working.
 
 Stage your changes and commit your new changes using,
 
-		$ git commit --amend
+```console
+# git commit --amend
+```
 
 '--amend' is required to ensure that you update your original commit and
 not create a new commit.

--- a/docs/GlusterFS Tools/gfind_missing_files.md
+++ b/docs/GlusterFS Tools/gfind_missing_files.md
@@ -1,5 +1,5 @@
-Introduction
-========
+## Introduction
+
 The tool gfind_missing_files.sh can be used to find the missing files in a
 GlusterFS geo-replicated slave volume. The tool uses a multi-threaded crawler
 operating on the backend .glusterfs of a brickpath which is passed as one of
@@ -15,10 +15,10 @@ gcrawler binary to do the backend crawling. The script detects the gfids of
 the missing files and runs the gfid-to-path conversion script to list out the
 missing files with their full pathnames.
 
-Usage
-=====
-```sh
-$bash gfind_missing_files.sh <BRICK_PATH> <SLAVE_HOST> <SLAVE_VOL> <OUTFILE>
+## Usage
+
+```console
+bash gfind_missing_files.sh <BRICK_PATH> <SLAVE_HOST> <SLAVE_VOL> <OUTFILE>
             BRICK_PATH -   Full path of the brick
             SLAVE_HOST -   Hostname of gluster volume
             SLAVE_VOL  -   Gluster volume name
@@ -29,10 +29,10 @@ The gfid-to-path conversion uses a quicker algorithm for converting gfids to
 paths and it is possible that in some cases all missing gfids may not be
 converted to their respective paths.
 
-Example output(126733 missing files)
-===================================
-```sh
-$ionice -c 2 -n 7 ./gfind_missing_files.sh /bricks/m3 acdc slave-vol ~/test_results/m3-4.txt
+## Example output(126733 missing files)
+
+```console
+# ionice -c 2 -n 7 ./gfind_missing_files.sh /bricks/m3 acdc slave-vol ~/test_results/m3-4.txt
 Calling crawler...
 Crawl Complete.
 gfids of skipped files are available in the file /root/test_results/m3-4.txt
@@ -42,26 +42,27 @@ WARNING: Unable to convert some GFIDs to Paths, GFIDs logged to /root/test_resul
 Use bash gfid_to_path.sh <brick-path> /root/test_results/m3-4.txt_gfids to convert those GFIDs to Path
 Total Missing File Count : 126733
 ```
+
 In such cases, an additional step is needed to convert those gfids to paths.
 This can be used as shown below:
-```sh
- $bash gfid_to_path.sh <BRICK_PATH> <GFID_FILE>
+
+```console
+bash gfid_to_path.sh <BRICK_PATH> <GFID_FILE>
              BRICK_PATH - Full path of the brick.
              GFID_FILE  - OUTFILE_gfids got from gfind_missing_files.sh
 ```
-Things to keep in mind when running the tool
-============================================
+
+## Things to keep in mind when running the tool
+
 1. Running this tool can result in a crawl of the backend filesystem at each
    brick which can be intensive. To ensure there is no impact on ongoing I/O on
    RHS volumes, we recommend that this tool be run at a low I/O scheduling class
    (best-effort) and priority.
-```sh
-$ionice -c 2 -p <pid of gfind_missing_files.sh>
-```
+
+        ionice -c 2 -p <pid of gfind_missing_files.sh>
 
 2. We do not recommend interrupting the tool when it is running
    (e.g. by doing CTRL^C). It is better to wait for the tool to finish
     execution. In case it is interrupted, manually unmount the Slave Volume.
-```sh
-    umount <MOUNT_POINT>
-```
+
+        umount <MOUNT_POINT>

--- a/docs/Install-Guide/Configure.md
+++ b/docs/Install-Guide/Configure.md
@@ -3,7 +3,9 @@
 For the Gluster to communicate within a cluster either the firewalls
 have to be turned off or enable communication for each server.
 
-		iptables -I INPUT -p all -s `<ip-address>` -j ACCEPT
+```console
+# iptables -I INPUT -p all -s `<ip-address>` -j ACCEPT
+```
 
 ### Configure the trusted pool
 
@@ -14,11 +16,13 @@ from this tutorial. Keep in mind, running many Gluster specific commands
 (like `gluster volume create`) on one server in the cluster will
 execute the same command on all other servers.
 
-Replace `nodename` with hostname of the other server in the cluster,
-or IP address if you don’t have DNS or `/etc/hosts` entries.
+Replace `nodename` with hostname of the other server in the cluster,
+or IP address if you don’t have DNS or `/etc/hosts` entries.
 Let say we want to connect to `node02`:
 
-		gluster peer probe node02
+```console
+# gluster peer probe node02
+```
 
 Notice that running `gluster peer status` from the second node shows
 that the first node has already been added.
@@ -27,21 +31,29 @@ that the first node has already been added.
 
 Assuming you have a empty disk at `/dev/sdb`:
 
-		fdisk /dev/sdb 
+```console
+# fdisk /dev/sdb 
+```
 
-And then create a single XFS partition using fdisk
+And then create a single XFS partition using fdisk
 
 ### Format the partition
 
-		mkfs.xfs -i size=512 /dev/sdb1
+```console
+# mkfs.xfs -i size=512 /dev/sdb1
+```
 
 ### Add an entry to /etc/fstab
 
-		echo "/dev/sdb1 /export/sdb1 xfs defaults 0 0"  >> /etc/fstab
+```console
+# echo "/dev/sdb1 /export/sdb1 xfs defaults 0 0"  >> /etc/fstab
+```
 
 ### Mount the partition as a Gluster "brick"
 
-		mkdir -p /export/sdb1 && mount -a && mkdir -p /export/sdb1/brick
+```console
+# mkdir -p /export/sdb1 && mount -a && mkdir -p /export/sdb1/brick
+```
 
 #### Set up a Gluster volume
 
@@ -57,13 +69,17 @@ something goes wrong.
 
 To set up a replicated volume:
 
-		gluster volume create gv0 replica 2 node01.mydomain.net:/export/sdb1/brick node02.mydomain.net:/export/sdb1/brick
+```console
+# gluster volume create gv0 replica 3 node01.mydomain.net:/export/sdb1/brick \
+    node02.mydomain.net:/export/sdb1/brick                                   \
+    node03.mydomain.net:/export/sdb1/brick
+```
 
 Breaking this down into pieces:
 
 - the first part says to create a gluster volume named gv0
-(the name is arbitrary, gv0 was chosen simply because
-it’s less typing than gluster\_volume\_0).
+(the name is arbitrary, `gv0` was chosen simply because
+it’s less typing than `gluster_volume_0`).
 - make the volume a replica volume
 - keep a copy of the data on at least 2 bricks at any given time.
 Since we only have two bricks total, this
@@ -79,19 +95,23 @@ cluster comes to a grinding halt when a single point of failure occurs.
 
 Now, we can check to make sure things are working as expected:
 
-		gluster volume info
+```console
+# gluster volume info
+```
 
 And you should see results similar to the following:
 
-	    Volume Name: gv0
-	    Type: Replicate
-	    Volume ID: 8bc3e96b-a1b6-457d-8f7a-a91d1d4dc019
-	    Status: Created
-	    Number of Bricks: 1 x 2 = 2
-	    Transport-type: tcp
-	    Bricks:
-	    Brick1: node01.yourdomain.net:/export/sdb1/brick
-	    Brick2: node02.yourdomain.net:/export/sdb1/brick
+```console
+Volume Name: gv0
+Type: Replicate
+Volume ID: 8bc3e96b-a1b6-457d-8f7a-a91d1d4dc019
+Status: Created
+Number of Bricks: 1 x 2 = 2
+Transport-type: tcp
+Bricks:
+Brick1: node01.yourdomain.net:/export/sdb1/brick
+Brick2: node02.yourdomain.net:/export/sdb1/brick
+```
 
 This shows us essentially what we just specified during the volume
 creation. The one this to mention is the `Status`. A status of `Created`
@@ -100,6 +120,8 @@ which would cause any attempt to mount the volume fail.
 
 Now, we should start the volume.
 
-		gluster volume start gv0
+```
+# gluster volume start gv0
+```
 
 Find all documentation [here](../index.md)

--- a/docs/Install-Guide/Install.md
+++ b/docs/Install-Guide/Install.md
@@ -13,43 +13,57 @@ Packages are provided according to this [table](./Community_Packages.md).
 
 Add the GPG key to apt:
 
-    wget -O - https://download.gluster.org/pub/gluster/glusterfs/LATEST/rsa.pub | apt-key add -
+```console
+# wget -O - https://download.gluster.org/pub/gluster/glusterfs/LATEST/rsa.pub | apt-key add -
+```
 
 If the rsa.pub is not available at the above location, please look here https://download.gluster.org/pub/gluster/glusterfs/3.12/rsa.pub and add the GPG key to apt:
 
-    wget -O - https://download.gluster.org/pub/gluster/glusterfs/3.12/rsa.pub | apt-key add -    
-   
+```console
+# wget -O - https://download.gluster.org/pub/gluster/glusterfs/3.12/rsa.pub | apt-key add -
+```
 
 Add the source:
 
-    DEBID=$(grep 'VERSION_ID=' /etc/os-release | cut -d '=' -f 2 | tr -d '"')
-    DEBVER=$(grep 'VERSION=' /etc/os-release | grep -Eo '[a-z]+')
-    DEBARCH=$(dpkg --print-architecture)
-    echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/${DEBARCH}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list
+```console
+# DEBID=$(grep 'VERSION_ID=' /etc/os-release | cut -d '=' -f 2 | tr -d '"')
+# DEBVER=$(grep 'VERSION=' /etc/os-release | grep -Eo '[a-z]+')
+# DEBARCH=$(dpkg --print-architecture)
+# echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/${DEBARCH}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list
+```
 
 Update package list:
 
-    apt-get update
+```console
+# apt-get update
+```
 
 Install:
 
-    apt-get install glusterfs-server
-
+```console
+# apt-get install glusterfs-server
+```
 
 ###### For Ubuntu
 
 Install software-properties-common:
 
-		sudo apt-get install software-properties-common
+```console
+# sudo apt-get install software-properties-common
+```
 
 Then add the community GlusterFS PPA:
 
-		sudo add-apt-repository ppa:gluster/glusterfs-3.8
-		sudo apt-get update
+```console
+# sudo add-apt-repository ppa:gluster/glusterfs-3.8
+# sudo apt-get update
+```
 
 Finally, install the packages:
 
-		sudo apt-get install glusterfs-server
+```console
+# sudo apt-get install glusterfs-server
+```
 
 *Note: Packages exist for Ubuntu 12.04 LTS, 12.10, 13.10, and 14.04
 LTS*
@@ -65,7 +79,9 @@ For more installation details refer [Gluster Quick start guide](https://wiki.cen
 
 Install the Gluster packages:
 
-		dnf install glusterfs-server
+```console
+# dnf install glusterfs-server
+```
 
 Once you are finished installing, you can move on to [configuration](./Configure.md) section.
 
@@ -73,4 +89,6 @@ Once you are finished installing, you can move on to [configuration](./Configure
 
 Install the Gluster package:
 
-        pacman -S glusterfs
+```console
+# pacman -S glusterfs
+```

--- a/docs/Install-Guide/compiling-rpms.md
+++ b/docs/Install-Guide/compiling-rpms.md
@@ -5,28 +5,28 @@ Creating rpm's of GlusterFS from git source is fairly easy, once you know the st
 
 RPMS can be compiled on at least the following OS's:
 
--   Red Hat Enterprise Linux 5, 6 (& 7 when available)
--   CentOS 5, 6 (& 7 when available)
--   Fedora 16-20
+- Red Hat Enterprise Linux 5, 6 (& 7 when available)
+- CentOS 5, 6 (& 7 when available)
+- Fedora 16-20
 
 Specific instructions for compiling are below. If you're using:
 
--   Fedora 16-20 - Follow the Fedora steps, then do all of the Common steps.
--   CentOS 5.x - Follow the CentOS 5.x steps, then do all of the Common steps
--   CentOS 6.x - Follow the CentOS 6.x steps, then do all of the Common steps.
--   RHEL 6.x - Follow the RHEL 6.x steps, then do all of the Common steps.
+- Fedora 16-20 - Follow the Fedora steps, then do all of the Common steps.
+- CentOS 5.x - Follow the CentOS 5.x steps, then do all of the Common steps
+- CentOS 6.x - Follow the CentOS 6.x steps, then do all of the Common steps.
+- RHEL 6.x - Follow the RHEL 6.x steps, then do all of the Common steps.
 
-Note - these instructions have been explicitly tested on all of CentOS 5.10, RHEL 6.4, CentOS 6.4+, and Fedora 16-20. Other releases of RHEL/CentOS and Fedora may work too, but haven't been tested. Please update this page appropriately if you do so. :)
+**Note** - these instructions have been explicitly tested on all of CentOS 5.10, RHEL 6.4, CentOS 6.4+, and Fedora 16-20. Other releases of RHEL/CentOS and Fedora may work too, but haven't been tested. Please update this page appropriately if you do so. :)
 
 ### Preparation steps for Fedora 16-20 (only)
 
 1. Install gcc, the python development headers, and python setuptools:
 
-        $ sudo yum -y install gcc python-devel python-setuptools
+        # sudo yum -y install gcc python-devel python-setuptools
 
 2. If you're compiling GlusterFS version 3.4, then install python-swiftclient. Other GlusterFS versions don't need it:
 
-        $ sudo easy_install simplejson python-swiftclient
+        # sudo easy_install simplejson python-swiftclient
 
 Now follow through the **Common Steps** part below.
 
@@ -36,13 +36,13 @@ You'll need EPEL installed first and some CentOS specific packages. The commands
 
 1. Install EPEL first:
 
-		$ curl -OL `[`http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm`](http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm)
-		$ sudo yum -y install epel-release-5-4.noarch.rpm --nogpgcheck
+		# curl -OL `[`http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm`](http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm)
+		# sudo yum -y install epel-release-5-4.noarch.rpm --nogpgcheck
 
 2. Install the packages required only on CentOS 5.x:
 
-		$ sudo yum -y install buildsys-macros gcc ncurses-devel python-ctypes python-sphinx10 \
-	    redhat-rpm-config
+		# sudo yum -y install buildsys-macros gcc ncurses-devel \
+            python-ctypes python-sphinx10 redhat-rpm-config
 
 Now follow through the **Common Steps** part below.
 
@@ -52,11 +52,11 @@ You'll need EPEL installed first and some CentOS specific packages. The commands
 
 1. Install EPEL first:
 
-		$ sudo yum -y install `[`http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm`](http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm)
+		# sudo yum -y install `[`http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm`](http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm)
 
 2. Install the packages required only on CentOS:
 
-		$ sudo yum -y install python-webob1.0 python-paste-deploy1.5 python-sphinx10 redhat-rpm-config
+		# sudo yum -y install python-webob1.0 python-paste-deploy1.5 python-sphinx10 redhat-rpm-config
 
 Now follow through the **Common Steps** part below.
 
@@ -66,12 +66,12 @@ You'll need EPEL installed first and some RHEL specific packages. The 2 commands
 
 1. Install EPEL first:
 
-		$ sudo yum -y install `[`http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm`](http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm)
+		# sudo yum -y install `[`http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm`](http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm)
 
 2. Install the packages required only on RHEL:
 
-		$ sudo yum -y --enablerepo=rhel-6-server-optional-rpms install python-webob1.0 \
-	    python-paste-deploy1.5 python-sphinx10 redhat-rpm-config
+		# sudo yum -y --enablerepo=rhel-6-server-optional-rpms install python-webob1.0 \
+	        python-paste-deploy1.5 python-sphinx10 redhat-rpm-config
 
 Now follow through the **Common Steps** part below.
 
@@ -81,71 +81,73 @@ These steps are for both Fedora and RHEL/CentOS. At the end you'll have the comp
 
 **NOTES for step 1 below:**
 
--   If you're on RHEL/CentOS 5.x and get a message about lvm2-devel not being available, it's ok. You can ignore it. :)
--   If you're on RHEL/CentOS 6.x and get any messages about python-eventlet, python-netifaces, python-sphinx and/or pyxattr not being available, it's ok. You can ignore them. :)
+- If you're on RHEL/CentOS 5.x and get a message about lvm2-devel not being available, it's ok. You can ignore it. :)
+- If you're on RHEL/CentOS 6.x and get any messages about python-eventlet, python-netifaces, python-sphinx and/or pyxattr not being available, it's ok. You can ignore them. :)
+
+<br/>
 
 1. Install the needed packages
 
-		$ sudo yum -y --disablerepo=rhs* --enablerepo=*optional-rpms install git autoconf \
-		  automake bison dos2unix flex fuse-devel glib2-devel libaio-devel \
-		  libattr-devel libibverbs-devel librdmacm-devel libtool libxml2-devel lvm2-devel make \
-		  openssl-devel pkgconfig pyliblzma python-devel python-eventlet python-netifaces \
-		  python-paste-deploy python-simplejson python-sphinx python-webob pyxattr readline-devel \
-		  rpm-build systemtap-sdt-devel tar libcmocka-devel
+		# sudo yum -y --disablerepo=rhs* --enablerepo=*optional-rpms install git autoconf \
+		    automake bison dos2unix flex fuse-devel glib2-devel libaio-devel \
+		    libattr-devel libibverbs-devel librdmacm-devel libtool libxml2-devel lvm2-devel make \
+		    openssl-devel pkgconfig pyliblzma python-devel python-eventlet python-netifaces \
+		    python-paste-deploy python-simplejson python-sphinx python-webob pyxattr readline-devel \
+		    rpm-build systemtap-sdt-devel tar libcmocka-devel
 
 2. Clone the GlusterFS git repository
 
-    	$ git clone `[`git://git.gluster.org/glusterfs`](git://git.gluster.org/glusterfs)
-		$ cd glusterfs
+    	# git clone `[`git://git.gluster.org/glusterfs`](git://git.gluster.org/glusterfs)
+		# cd glusterfs
 
 3. Choose which branch to compile
 
-If you want to compile the latest development code, you can skip this step and go on to the next one. :)
+    If you want to compile the latest development code, you can skip this step and go on to the next one. :)
 
-If instead you want to compile the code for a specific release of GlusterFS (such as v3.4), get the list of release names here:
+    If instead you want to compile the code for a specific release of GlusterFS (such as v3.4), get the list of release names here:
 
-		$ git branch -a | grep release
-		  remotes/origin/release-2.0
-		  remotes/origin/release-3.0
-		  remotes/origin/release-3.1
-		  remotes/origin/release-3.2
-		  remotes/origin/release-3.3
-		  remotes/origin/release-3.4
-		  remotes/origin/release-3.5
+		# git branch -a | grep release
+		remotes/origin/release-2.0
+		remotes/origin/release-3.0
+		remotes/origin/release-3.1
+		remotes/origin/release-3.2
+		remotes/origin/release-3.3
+		remotes/origin/release-3.4
+		remotes/origin/release-3.5
 
-Then switch to the correct release using the git "checkout" command, and the name of the release after the "remotes/origin/" bit from the list above:
+    Then switch to the correct release using the git "checkout" command, and the name of the release after the "remotes/origin/" bit from the list above:
 
-		$ git checkout release-3.4
+		# git checkout release-3.4
 
-**NOTE -** The CentOS 5.x instructions have only been tested for the master branch in GlusterFS git. It is unknown (yet) if they work for branches older then release-3.5.
+    **NOTE -** The CentOS 5.x instructions have only been tested for the master branch in GlusterFS git. It is unknown (yet) if they work for branches older then release-3.5.
 
 4. Configure and compile GlusterFS
 
-Now you're ready to compile Gluster:
+    Now you're ready to compile Gluster:
 
-		$ ./autogen.sh
-		$ ./configure --enable-fusermount
-		$ make dist
+		# ./autogen.sh
+		# ./configure --enable-fusermount
+		# make dist
 
 5. Create the GlusterFS RPMs
 
-		$ cd extras/LinuxRPM
-		$ make glusterrpms
+		# cd extras/LinuxRPM
+		# make glusterrpms
 
-That should complete with no errors, leaving you with a directory containing the RPMs.
+    That should complete with no errors, leaving you with a directory containing the RPMs.
 
-		$ ls -l *rpm
-		-rw-rw-r-- 1 jc jc 3966111 Mar  2 12:15 glusterfs-3git-1.el5.centos.src.rpm
-		-rw-rw-r-- 1 jc jc 1548890 Mar  2 12:17 glusterfs-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc   66680 Mar  2 12:17 glusterfs-api-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc   20399 Mar  2 12:17 glusterfs-api-devel-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc  123806 Mar  2 12:17 glusterfs-cli-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc 7850357 Mar  2 12:17 glusterfs-debuginfo-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc  112677 Mar  2 12:17 glusterfs-devel-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc  100410 Mar  2 12:17 glusterfs-fuse-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc  187221 Mar  2 12:17 glusterfs-geo-replication-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc  299171 Mar  2 12:17 glusterfs-libs-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc   44943 Mar  2 12:17 glusterfs-rdma-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc  123065 Mar  2 12:17 glusterfs-regression-tests-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc   16224 Mar  2 12:17 glusterfs-resource-agents-3git-1.el5.centos.x86_64.rpm
-		-rw-rw-r-- 1 jc jc  654043 Mar  2 12:17 glusterfs-server-3git-1.el5.centos.x86_64.rpm
+        # ls -l *rpm
+        -rw-rw-r-- 1 jc jc 3966111 Mar	2 12:15 glusterfs-3git-1.el5.centos.src.rpm
+        -rw-rw-r-- 1 jc jc 1548890 Mar	2 12:17 glusterfs-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	 66680 Mar	2 12:17 glusterfs-api-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	 20399 Mar	2 12:17 glusterfs-api-devel-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	123806 Mar	2 12:17 glusterfs-cli-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc 7850357 Mar	2 12:17 glusterfs-debuginfo-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	112677 Mar	2 12:17 glusterfs-devel-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	100410 Mar	2 12:17 glusterfs-fuse-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	187221 Mar	2 12:17 glusterfs-geo-replication-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	299171 Mar	2 12:17 glusterfs-libs-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	 44943 Mar	2 12:17 glusterfs-rdma-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	123065 Mar	2 12:17 glusterfs-regression-tests-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	 16224 Mar	2 12:17 glusterfs-resource-agents-3git-1.el5.centos.x86_64.rpm
+        -rw-rw-r-- 1 jc jc	654043 Mar	2 12:17 glusterfs-server-3git-1.el5.centos.x86_64.rpm

--- a/docs/Quick-Start-Guide/Architecture.md
+++ b/docs/Quick-Start-Guide/Architecture.md
@@ -24,29 +24,33 @@ hardware for data loss protection.
 
 Create a Distributed Volume
 
-**gluster volume create NEW-VOLNAME [transport [tcp | rdma | tcp,rdma]]
-NEW-BRICK...**
+```console
+gluster volume create NEW-VOLNAME [transport [tcp | rdma | tcp,rdma]] NEW-BRICK...
+```
 
 **For example** to create a distributed volume with four storage servers
 using TCP.
 
-    gluster volume create test-volume server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4
-    Creation of test-volume has been successful
-    Please start the volume to access data
+```console
+# gluster volume create test-volume server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4
+volume create: test-volume: success: please start the volume to access data
+```
 
 To display the volume info
 
-    #gluster volume info
-    Volume Name: test-volume
-    Type: Distribute
-    Status: Created
-    Number of Bricks: 4
-    Transport-type: tcp
-    Bricks:
-    Brick1: server1:/exp1
-    Brick2: server2:/exp2
-    Brick3: server3:/exp3
-    Brick4: server4:/exp4
+```console
+# gluster volume info
+Volume Name: test-volume
+Type: Distribute
+Status: Created
+Number of Bricks: 4
+Transport-type: tcp
+Bricks:
+Brick1: server1:/exp1
+Brick2: server2:/exp2
+Brick3: server3:/exp3
+Brick4: server4:/exp4
+```
 
 ​2. **Replicated Glusterfs Volume** - In this volume we overcome the
 data loss problem faced in the distributed volume. Here exact copies of
@@ -64,14 +68,17 @@ reliability and data redundancy.
 
 Create a Replicated Volume
 
-**gluster volume create NEW-VOLNAME [replica COUNT] [transport [tcp |
-rdma | tcp,rdma]] NEW-BRICK...**
+```console
+gluster volume create NEW-VOLNAME [replica COUNT] [transport [tcp |rdma | tcp,rdma]] NEW-BRICK...
+```
 
 **For example**, to create a replicated volume with two storage servers:
 
-    # gluster volume create test-volume replica 2 transport tcp server1:/exp1 server2:/exp2
-    Creation of test-volume has been successful
-    Please start the volume to access data
+```console
+# gluster volume create test-volume replica 3 transport tcp \
+      server1:/exp1 server2:/exp2 server3:/exp3
+volume create: test-volume: success: please start the volume to access data
+```
 
 ​3. **Distributed Replicated Glusterfs Volume** - In this volume files
 are distributed across replicated sets of bricks. The number of bricks
@@ -91,16 +98,17 @@ volume.
 
 Create the distributed replicated volume:
 
-**\# gluster volume create
-NEW-VOLNAME [replica COUNT] [transport [tcp | rdma | tcp,rdma]]
-NEW-BRICK...**
+```console
+gluster volume create NEW-VOLNAME [replica COUNT] [transport [tcp | rdma | tcp,rdma]] NEW-BRICK...
+```
 
 **For example**, four node distributed (replicated) volume with a two-way
 mirror:
 
-    # gluster volume create test-volume replica 2 transport tcp server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4
-    Creation of test-volume has been successful
-    Please start the volume to access data
+```console
+# gluster volume create test-volume replica 3 transport tcp server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4 server5:/exp5 server6:/exp6
+volume create: test-volume: success: please start the volume to access data
+```
 
 ​4. **Striped Glusterfs Volume** - Consider a large file being stored in
 a brick which is frequently accessed by many clients at the same time.
@@ -117,13 +125,16 @@ file can be fetched faster but no data redundancy provided.
 
 Create a Striped Volume
 
-    gluster volume create NEW-VOLNAME [stripe COUNT] [transport [tcp | dma | tcp,rdma]] NEW-BRICK...
+```console
+gluster volume create NEW-VOLNAME [stripe COUNT] [transport [tcp | dma | tcp,rdma]] NEW-BRICK...
+```
 
 **For example**, to create a striped volume across two storage servers:
 
-    # gluster volume create test-volume stripe 2 transport tcp server1:/exp1 server2:/exp2
-    Creation of test-volume has been successful
-    Please start the volume to access data
+```console
+# gluster volume create test-volume stripe 2 transport tcp server1:/exp1 server2:/exp2
+volume create: test-volume: success: please start the volume to access data
+```
 
 ​5. **Distributed Striped Glusterfs Volume** - This is similar to
 Striped Glusterfs volume except that the stripes can now be distributed
@@ -137,16 +148,19 @@ we must add bricks in the multiple of stripe count.
 
 Create the distributed striped volume:
 
-**gluster volume create NEW-VOLNAME [stripe COUNT] [transport [tcp |
-rdma | tcp,rdma]] NEW-BRICK...**
+```console
+gluster volume create NEW-VOLNAME [stripe COUNT] [transport [tcp | rdma | tcp,rdma]] NEW-BRICK...
+```
 
 For example, to create a distributed striped volume across eight
 storage servers:
 
-    # gluster volume create test-volume stripe 4 transport tcp
-     server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4 server5:/exp5 server6:/exp6 server7:/exp7 server8:/exp8
-    Creation of test-volume has been successful
-    Please start the volume to access data.
+```console
+# gluster volume create test-volume stripe 4 transport tcp \
+      server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4 \
+      server5:/exp5 server6:/exp6 server7:/exp7 server8:/exp8
+volume create: test-volume: success: please start the volume to access data
+```
 
 ### FUSE
 
@@ -194,14 +208,14 @@ descriptor with the mounted filesystem.
 
 -   A translator converts requests from users into requests for storage.
 
-    *One to one, one to many, one to zero (e.g. caching)
+    *One to one, one to many, one to zero (e.g. caching)
 
 ![translator](https://cloud.githubusercontent.com/assets/10970993/7412595/fd46c492-ef61-11e4-8f49-61dbd15b9695.png)
 
 -   A translator can modify requests on the way through :
 
-    *convert one request type to another ( during the request transfer amongst the translators)
-    *modify paths, flags, even data (e.g. encryption)
+    *convert one request type to another ( during the request transfer amongst the translators)
+    *modify paths, flags, even data (e.g. encryption)
 
 -   Translators can intercept or block the requests. (e.g. access
     control)
@@ -214,9 +228,9 @@ descriptor with the mounted filesystem.
 -   Dynamically loaded according to 'volfile'
 
     *dlopen/dlsync
-    *setup pointers to parents / children
-    *call init (constructor)
-    *call IO functions through fops.
+    *setup pointers to parents / children
+    *call init (constructor)
+    *call IO functions through fops.
 
 -   Conventions for validating/ passing options, etc.
 -   The configuration of translators (since GlusterFS 3.1) is managed
@@ -257,43 +271,32 @@ to go through is **fuse translator** which falls under the category of
 
 1.  **Cluster Translators**:
 
-    *DHT(Distributed Hash Table)
-
-    *AFR(Automatic File Replication)
+    * DHT(Distributed Hash Table)
+    * AFR(Automatic File Replication)
 
 1.  **Performance Translators**:
 
-    * io-cache
-
-    * io-threads
-
-    * md-cache
-
-    * O-B (open behind)
-
-    * QR (quick read)
-
-    * r-a (read-ahead)
-
-    * w-b (write-behind)
+    * io-cache
+    * io-threads
+    * md-cache
+    * O-B (open behind)
+    * QR (quick read)
+    * r-a (read-ahead)
+    * w-b (write-behind)
 
 Other **Feature Translators** include:
 
-* changelog
-
-  * locks - GlusterFS has locks  translator which provides the following internal locking operations
-  called `inodelk`, `entrylk`,
-  which are used by afr to achieve synchronization of operations on files or directories that conflict with each other.
-
-* marker
-
-* quota
+* changelog
+* locks - GlusterFS has locks  translator which provides the following internal locking operations
+  called `inodelk`, `entrylk`,
+  which are used by afr to achieve synchronization of operations on files or directories that conflict with each other.
+* marker
+* quota
 
 **Debug Translators**
 
-    * trace - To trace the error logs generated during the communication amongst the translators.
-
-    * io-stats
+* trace - To trace the error logs generated during the communication amongst the translators.
+* io-stats
 
 #### DHT(Distributed Hash Table) Translator
 
@@ -502,7 +505,9 @@ a client process will also be created. Now our filesystem is ready to
 use. We can mount this volume on a client machine very easily as follows
 and use it like we use a local storage:
 
-    mount.glusterfs `<IP or hostname>`:`<volume_name>` `<mount_point>
+```console
+mount.glusterfs <IP or hostname>:<volume_name> <mount_point>
+```
 
 IP or hostname can be that of any node in the trusted server pool in
 which the required volume is created.

--- a/docs/Quick-Start-Guide/Quickstart.md
+++ b/docs/Quick-Start-Guide/Quickstart.md
@@ -68,10 +68,12 @@ Perform this step on all the nodes, "server{1,2,3}"
 
 The following examples assume that the brick will be residing on /dev/sdb1.
 
-		mkfs.xfs -i size=512 /dev/sdb1
-		mkdir -p /data/brick1
-		echo '/dev/sdb1 /data/brick1 xfs defaults 1 2' >> /etc/fstab
-		mount -a && mount
+```console
+# mkfs.xfs -i size=512 /dev/sdb1
+# mkdir -p /data/brick1
+# echo '/dev/sdb1 /data/brick1 xfs defaults 1 2' >> /etc/fstab
+# mount -a && mount
+```
 
 You should now see sdb1 mounted at /data/brick1
 
@@ -80,21 +82,24 @@ You should now see sdb1 mounted at /data/brick1
 
 Install the software
 
-		yum install glusterfs-server
+```console
+# yum install glusterfs-server
+```
 
 Start the GlusterFS management daemon:
 
-		service glusterd start
-		service glusterd status
-		glusterd.service - LSB: glusterfs server
-		       Loaded: loaded (/etc/rc.d/init.d/glusterd)
-		   Active: active (running) since Mon, 13 Aug 2012 13:02:11 -0700; 2s ago
-		  Process: 19254 ExecStart=/etc/rc.d/init.d/glusterd start (code=exited, status=0/SUCCESS)
-		   CGroup: name=systemd:/system/glusterd.service
-		       ├ 19260 /usr/sbin/glusterd -p /run/glusterd.pid
-		       ├ 19304 /usr/sbin/glusterfsd --xlator-option georep-server.listen-port=24009 -s localhost...
-		       └ 19309 /usr/sbin/glusterfs -f /var/lib/glusterd/nfs/nfs-server.vol -p /var/lib/glusterd/...
-
+```console
+# service glusterd start
+# service glusterd status
+glusterd.service - LSB: glusterfs server
+       Loaded: loaded (/etc/rc.d/init.d/glusterd)
+   Active: active (running) since Mon, 13 Aug 2012 13:02:11 -0700; 2s ago
+   Process: 19254 ExecStart=/etc/rc.d/init.d/glusterd start (code=exited, status=0/SUCCESS)
+   CGroup: name=systemd:/system/glusterd.service
+       ├ 19260 /usr/sbin/glusterd -p /run/glusterd.pid
+	   ├ 19304 /usr/sbin/glusterfsd --xlator-option georep-server.listen-port=24009 -s localhost...
+	   └ 19309 /usr/sbin/glusterfs -f /var/lib/glusterd/nfs/nfs-server.vol -p /var/lib/glusterd/...
+```
 
         
 ### Step 4 - Configure the firewall
@@ -102,7 +107,9 @@ Start the GlusterFS management daemon:
 The gluster processes on the nodes need to be able to communicate with each other.
 To simplify this setup, configure the firewall on each node to accept all traffic from the other node.
 
-                iptables -I INPUT -p all -s <ip-address> -j ACCEPT
+```console
+# iptables -I INPUT -p all -s <ip-address> -j ACCEPT
+```
 
 where ip-address is the address of the other node.
 
@@ -111,15 +118,19 @@ where ip-address is the address of the other node.
 
 From "server1"
 
-		gluster peer probe server2
-		gluster peer probe server3
+```console
+# gluster peer probe server2
+# gluster peer probe server3
+```
 
 Note: When using hostnames, the first server needs to be probed from
 ***one*** other server to set its hostname.
 
 From "server2"
 
-		gluster peer probe server1
+```console
+# gluster peer probe server1
+```
 
 Note: Once this pool has been established, only trusted members may
 probe new servers into the pool. A new server cannot probe the pool, it
@@ -127,53 +138,64 @@ must be probed from the pool.
 
 Check the peer status on server1
 
-                gluster peer status
+```console
+# gluster peer status
+```
 
 You should see something like this (the UUID will differ)
 
-                Number of Peers: 2
+```console
+Number of Peers: 2
 
-                Hostname: server2
-                Uuid: f0e7b138-4874-4bc0-ab91-54f20c7068b4
-                State: Peer in Cluster (Connected)
+Hostname: server2
+Uuid: f0e7b138-4874-4bc0-ab91-54f20c7068b4
+State: Peer in Cluster (Connected)
 
-                Hostname: server3
-                Uuid: f0e7b138-4532-4bc0-ab91-54f20c701241
-                State: Peer in Cluster (Connected)
-
+Hostname: server3
+Uuid: f0e7b138-4532-4bc0-ab91-54f20c701241
+State: Peer in Cluster (Connected)
+```
 
 ### Step 6 - Set up a GlusterFS volume
 
 On all servers:
 
-		mkdir -p /data/brick1/gv0
+```console
+# mkdir -p /data/brick1/gv0
+```
 
 From any single server:
 
-		gluster volume create gv0 replica 3 server1:/data/brick1/gv0 server2:/data/brick1/gv0 server3:/data/brick1/gv0
-		gluster volume start gv0
+```console
+# gluster volume create gv0 replica 3 server1:/data/brick1/gv0 server2:/data/brick1/gv0 server3:/data/brick1/gv0
+volume create: gv0: success: please start the volume to access data
+# gluster volume start gv0
+volume start: gv0: success
+```
 
 Confirm that the volume shows "Started":
 
-		gluster volume info
-
+```console
+# gluster volume info
+```
 
 You should see something like this (the Volume ID will differ):
 
-                Volume Name: gv0
-                Type: Replicate
-                Volume ID: f25cc3d8-631f-41bd-96e1-3e22a4c6f71f
-                Status: Started
-                Snapshot Count: 0
-                Number of Bricks: 1 x 3 = 3
-                Transport-type: tcp
-                Bricks:
-                Brick1: server1:/data/brick1/gv0
-                Brick2: server2:/data/brick1/gv0
-                Brick3: server3:/data/brick1/gv0
-                Options Reconfigured:
-                transport.address-family: inet
-
+```console
+Volume Name: gv0
+Type: Replicate
+Volume ID: f25cc3d8-631f-41bd-96e1-3e22a4c6f71f
+Status: Started
+Snapshot Count: 0
+Number of Bricks: 1 x 3 = 3
+Transport-type: tcp
+Bricks:
+Brick1: server1:/data/brick1/gv0
+Brick2: server2:/data/brick1/gv0
+Brick3: server3:/data/brick1/gv0
+Options Reconfigured:
+transport.address-family: inet
+```
 
 Note: If the volume does not show "Started", the files under
 `/var/log/glusterfs/glusterd.log` should be checked in order to debug and
@@ -189,17 +211,23 @@ Typically, you would do this from an external machine, known as a
 be installed on the client machine, we will use one of the servers as
 a simple place to test first , as if it were that "client".
 
-		mount -t glusterfs server1:/gv0 /mnt
-		  for i in `seq -w 1 100`; do cp -rp /var/log/messages /mnt/copy-test-$i; done
+```console
+# mount -t glusterfs server1:/gv0 /mnt
+# for i in `seq -w 1 100`; do cp -rp /var/log/messages /mnt/copy-test-$i; done
+```
 
 First, check the client mount point:
 
-		ls -lA /mnt/copy* | wc -l
+```console
+# ls -lA /mnt/copy* | wc -l
+```
 
 You should see 100 files returned. Next, check the GlusterFS brick mount
 points on each server:
 
-		ls -lA /data/brick1/gv0/copy*
+```console
+# ls -lA /data/brick1/gv0/copy*
+```
 
 You should see 100 files on each server using the method we listed here.
 Without replication, in a distribute only volume (not detailed here), you

--- a/docs/Troubleshooting/gfid-to-path.md
+++ b/docs/Troubleshooting/gfid-to-path.md
@@ -6,32 +6,37 @@ normal filesystem. The GFID of a file is stored in its xattr named
 `trusted.gfid`.
 
 #### Special mount using gfid-access translator:
-~~~
-mount -t glusterfs -o aux-gfid-mount vm1:test /mnt/testvol
-~~~
+
+```console
+# mount -t glusterfs -o aux-gfid-mount vm1:test /mnt/testvol
+```
 
 Assuming, you have `GFID` of a file from changelog (or somewhere else).
 For trying this out, you can get `GFID` of a file from mountpoint:
-~~~
-getfattr -n glusterfs.gfid.string /mnt/testvol/dir/file
-~~~
 
+```console
+# getfattr -n glusterfs.gfid.string /mnt/testvol/dir/file
+```
 
 ---
 ### Get file path from GFID (Method 1):
 **(Lists hardlinks delimited by `:`, returns path as seen from mountpoint)**
 
 #### Turn on build-pgfid option
-~~~
-gluster volume set test build-pgfid on
-~~~
+
+```console
+# gluster volume set test build-pgfid on
+```
+
 Read virtual xattr `glusterfs.ancestry.path` which contains the file path
-~~~
+
+```console
 getfattr -n glusterfs.ancestry.path -e text /mnt/testvol/.gfid/<GFID>
-~~~
+```
 
 **Example:**
-~~~
+
+```console
 [root@vm1 glusterfs]# ls -il /mnt/testvol/dir/
 total 1
 10610563327990022372 -rw-r--r--. 2 root root 3 Jul 17 18:05 file
@@ -46,24 +51,23 @@ glusterfs.gfid.string="11118443-1894-4273-9340-4b212fa1c0e4"
 getfattr: Removing leading '/' from absolute path names
 # file: mnt/testvol/.gfid/11118443-1894-4273-9340-4b212fa1c0e4
 glusterfs.ancestry.path="/dir/file:/dir/file3"
-~~~
+```
 
----
 ### Get file path from GFID (Method 2):
 **(Does not list all hardlinks, returns backend brick path)**
-~~~
+
+```console
 getfattr -n trusted.glusterfs.pathinfo -e text /mnt/testvol/.gfid/<GFID>
-~~~
+```
 
 **Example:**
-~~~
+
+```console
 [root@vm1 glusterfs]# getfattr -n trusted.glusterfs.pathinfo -e text /mnt/testvol/.gfid/11118443-1894-4273-9340-4b212fa1c0e4
 getfattr: Removing leading '/' from absolute path names
 # file: mnt/testvol/.gfid/11118443-1894-4273-9340-4b212fa1c0e4
 trusted.glusterfs.pathinfo="(<DISTRIBUTE:test-dht> <POSIX(/mnt/brick-test/b):vm1:/mnt/brick-test/b/dir//file3>)"
-~~~
+```
 
----
----
 #### References and links:
 [posix: placeholders for GFID to path conversion](http://review.gluster.org/5951)

--- a/docs/Troubleshooting/resolving-splitbrain.md
+++ b/docs/Troubleshooting/resolving-splitbrain.md
@@ -14,12 +14,13 @@ There are three types of split-brains:
 -  Entry/GFID split-brain: The GFID of the file is different on the bricks in the replica. This cannot be healed automatically.
 
 
-## 1) Volume heal info:  
-Usage: `gluster volume heal <VOLNAME> info`  
+## 1) Volume heal info:
+Usage: `gluster volume heal <VOLNAME> info`
+
 This lists all the files that require healing (and will be processed by the self-heal daemon). It prints either their path or their GFID.
 
 ### Interpreting the output
-All the files listed in the output of this command need to be healed. 
+All the files listed in the output of this command need to be healed.
 The files listed may also be accompanied by the following tags:
 
 a) 'Is in split-brain'  
@@ -39,30 +40,30 @@ The following is an example of heal info command's output.
 Consider a replica volume "test" with two bricks b1 and b2;
 self-heal daemon off, mounted at /mnt.
 
-`gluster volume heal test info`
-~~~
-Brick \<hostname:brickpath-b1>  
+```console
+# gluster volume heal test info
+Brick \<hostname:brickpath-b1>
 <gfid:aaca219f-0e25-4576-8689-3bfd93ca70c2> - Is in split-brain
 <gfid:39f301ae-4038-48c2-a889-7dac143e82dd> - Is in split-brain
 <gfid:c3c94de2-232d-4083-b534-5da17fc476ac> - Is in split-brain
-<gfid:6dc78b20-7eb6-49a3-8edb-087b90142246> 
+<gfid:6dc78b20-7eb6-49a3-8edb-087b90142246>
 
 Number of entries: 4
 
 Brick <hostname:brickpath-b2>
-/dir/file2 
+/dir/file2
 /dir/file1 - Is in split-brain
 /dir - Is in split-brain
-/dir/file3 
+/dir/file3
 /file4 - Is in split-brain
-/dir/a 
+/dir/a
 
 
 Number of entries: 6
-~~~
+```
 
 ### Analysis of the output
-It can be seen that  
+It can be seen that
 A) from brick b1, four entries need healing:   
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1) file with gfid:6dc78b20-7eb6-49a3-8edb-087b90142246 needs healing  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2) "aaca219f-0e25-4576-8689-3bfd93ca70c2",
@@ -78,8 +79,9 @@ Usage: `gluster volume heal <VOLNAME> info split-brain`
 This command only shows the list of files that are in split-brain. The output is therefore a subset of `gluster volume heal <VOLNAME> info`
 
 ### Example
-`gluster volume heal test info split-brain`
-~~~
+
+```console
+# gluster volume heal test info split-brain
 Brick <hostname:brickpath-b1>
 <gfid:aaca219f-0e25-4576-8689-3bfd93ca70c2>
 <gfid:39f301ae-4038-48c2-a889-7dac143e82dd>
@@ -91,7 +93,8 @@ Brick <hostname:brickpath-b2>
 /dir
 /file4
 Number of entries in split-brain: 3
-~~~
+```
+
 Note that similar to the heal info command, for GFID split-brains (same filename but different GFID) 
 their parent directories are listed to be in split-brain.
 
@@ -112,9 +115,11 @@ size is found and healing is completed with that brick as a source.
 Consider the earlier output of the heal info split-brain command.
 
 Before healing the file, notice file size and md5 checksums :  
-~~~
+
 On brick b1:
-# stat b1/dir/file1 
+
+```console
+[brick1]# stat b1/dir/file1
   File: ‘b1/dir/file1’
   Size: 17              Blocks: 16         IO Block: 4096   regular file
 Device: fd03h/64771d    Inode: 919362      Links: 2
@@ -123,12 +128,15 @@ Access: 2015-03-06 13:55:40.149897333 +0530
 Modify: 2015-03-06 13:55:37.206880347 +0530
 Change: 2015-03-06 13:55:37.206880347 +0530
  Birth: -
-
-# md5sum b1/dir/file1 
+[brick1]#
+[brick1]# md5sum b1/dir/file1
 040751929ceabf77c3c0b3b662f341a8  b1/dir/file1
+```
 
 On brick b2:
-# stat b2/dir/file1 
+
+```console
+[brick2]# stat b2/dir/file1
   File: ‘b2/dir/file1’
   Size: 13              Blocks: 16         IO Block: 4096   regular file
 Device: fd03h/64771d    Inode: 919365      Links: 2
@@ -137,17 +145,21 @@ Access: 2015-03-06 13:54:22.974451898 +0530
 Modify: 2015-03-06 13:52:22.910758923 +0530
 Change: 2015-03-06 13:52:22.910758923 +0530
  Birth: -
-# md5sum b2/dir/file1 
+[brick2]#
+[brick2]# md5sum b2/dir/file1
 cb11635a45d45668a403145059c2a0d5  b2/dir/file1
-~~~
+```
+
 **Healing file1 using the above command** :-    
 `gluster volume heal test split-brain bigger-file /dir/file1`  
 Healed /dir/file1.
 
 After healing is complete, the md5sum and file size on both bricks should be the same.
-~~~
+
 On brick b1:
-# stat b1/dir/file1 
+
+```console
+[brick1]# stat b1/dir/file1
   File: ‘b1/dir/file1’
   Size: 17              Blocks: 16         IO Block: 4096   regular file
 Device: fd03h/64771d    Inode: 919362      Links: 2
@@ -156,11 +168,15 @@ Access: 2015-03-06 14:17:27.752429505 +0530
 Modify: 2015-03-06 13:55:37.206880347 +0530
 Change: 2015-03-06 14:17:12.880343950 +0530
  Birth: -
-# md5sum b1/dir/file1 
+[brick1]#
+[brick1]# md5sum b1/dir/file1
 040751929ceabf77c3c0b3b662f341a8  b1/dir/file1
+```
 
 On brick b2:
-# stat b2/dir/file1 
+
+```console
+[brick2]# stat b2/dir/file1
   File: ‘b2/dir/file1’
   Size: 17              Blocks: 16         IO Block: 4096   regular file
 Device: fd03h/64771d    Inode: 919365      Links: 2
@@ -169,26 +185,36 @@ Access: 2015-03-06 14:17:23.249403600 +0530
 Modify: 2015-03-06 13:55:37.206880000 +0530
 Change: 2015-03-06 14:17:12.881343955 +0530
  Birth: -
-
-# md5sum b2/dir/file1 
+[brick2]#
+[brick2]# md5sum b2/dir/file1
 040751929ceabf77c3c0b3b662f341a8  b2/dir/file1
-~~~
-## ii) Select the file with the latest mtime as source  
-`gluster volume heal <VOLNAME> split-brain latest-mtime <FILE>`  
+```
+
+## ii) Select the file with the latest mtime as source
+
+```console
+gluster volume heal <VOLNAME> split-brain latest-mtime <FILE>
+```
+
 As is perhaps self-explanatory, this command uses the brick having the latest modification time for `<FILE>` as the source for healing.
 
 ## iii) Select one of the bricks in the replica as the source for a particular file
-`gluster volume heal <VOLNAME> split-brain source-brick <HOSTNAME:BRICKNAME> <FILE>`  
+
+```console
+gluster volume heal <VOLNAME> split-brain source-brick <HOSTNAME:BRICKNAME> <FILE>
+```
+
 Here, `<HOSTNAME:BRICKNAME>` is selected as source brick and `<FILE>` present in the source brick is taken as the source for healing.
 
 ### Example :
 Notice the md5 checksums and file size before and after healing.
 
 Before heal :
-~~~
+
 On brick b1:
 
- stat b1/file4 
+```console
+[brick1]# stat b1/file4
   File: ‘b1/file4’
   Size: 4               Blocks: 16         IO Block: 4096   regular file
 Device: fd03h/64771d    Inode: 919356      Links: 2
@@ -197,12 +223,15 @@ Access: 2015-03-06 13:53:19.417085062 +0530
 Modify: 2015-03-06 13:53:19.426085114 +0530
 Change: 2015-03-06 13:53:19.426085114 +0530
  Birth: -
-# md5sum b1/file4
+[brick1]#
+[brick1]# md5sum b1/file4
 b6273b589df2dfdbd8fe35b1011e3183  b1/file4
+```
 
 On brick b2:
 
-# stat b2/file4 
+```console
+[brick2]# stat b2/file4
   File: ‘b2/file4’
   Size: 4               Blocks: 16         IO Block: 4096   regular file
 Device: fd03h/64771d    Inode: 919358      Links: 2
@@ -211,17 +240,25 @@ Access: 2015-03-06 13:52:35.761833096 +0530
 Modify: 2015-03-06 13:52:35.769833142 +0530
 Change: 2015-03-06 13:52:35.769833142 +0530
  Birth: -
-# md5sum b2/file4
+[brick2]#
+[brick2]# md5sum b2/file4
 0bee89b07a248e27c83fc3d5951213c1  b2/file4
-~~~
-**Healing the file with gfid c3c94de2-232d-4083-b534-5da17fc476ac using the above command** :  
-`gluster volume heal test split-brain source-brick test-host:/test/b1 gfid:c3c94de2-232d-4083-b534-5da17fc476ac`  
+```
+
+**Healing the file with gfid c3c94de2-232d-4083-b534-5da17fc476ac using the above command** :
+
+```console
+# gluster volume heal test split-brain source-brick test-host:/test/b1 gfid:c3c94de2-232d-4083-b534-5da17fc476ac
+```
+
 Healed gfid:c3c94de2-232d-4083-b534-5da17fc476ac.
 
 After healing :
-~~~
+
 On brick b1:
-# stat b1/file4 
+
+```console
+# stat b1/file4
   File: ‘b1/file4’
   Size: 4               Blocks: 16         IO Block: 4096   regular file
 Device: fd03h/64771d    Inode: 919356      Links: 2
@@ -232,8 +269,11 @@ Change: 2015-03-06 14:27:15.058927962 +0530
  Birth: -
 # md5sum b1/file4
 b6273b589df2dfdbd8fe35b1011e3183  b1/file4
+```
 
 On brick b2:
+
+```console
 # stat b2/file4
  File: ‘b2/file4’
   Size: 4               Blocks: 16         IO Block: 4096   regular file
@@ -245,31 +285,40 @@ Change: 2015-03-06 14:27:15.059927968 +0530
  Birth: -
 # md5sum b2/file4
 b6273b589df2dfdbd8fe35b1011e3183  b2/file4
-~~~
+```
 
 ## iv) Select one brick of the replica as the source for all files
-`gluster volume heal <VOLNAME> split-brain source-brick <HOSTNAME:BRICKNAME>`  
+
+```console
+gluster volume heal <VOLNAME> split-brain source-brick <HOSTNAME:BRICKNAME>
+```
+
 Consider a scenario where many files are in split-brain such that one brick of
 replica pair is source. As the result of the above command all split-brained
 files in `<HOSTNAME:BRICKNAME>` are selected as source and healed to the sink.
 
 ### Example:
 Consider a volume having three entries "a, b and c" in split-brain.
-~~~
-`gluster volume heal test split-brain source-brick test-host:/test/b1`
+
+```console
+# gluster volume heal test split-brain source-brick test-host:/test/b1
 Healed gfid:944b4764-c253-4f02-b35f-0d0ae2f86c0f.
 Healed gfid:3256d814-961c-4e6e-8df2-3a3143269ced.
 Healed gfid:b23dd8de-af03-4006-a803-96d8bc0df004.
 Number of healed entries: 3
-~~~
+```
 
 ## Note:
 As mentioned earlier, entry split-brain and gfid split-brain healing
  are not supported using CLI. Trying to heal /dir would fail as it is in entry split-brain.
+
 ### Example
-`gluster volume heal test split-brain source-brick test-host:/test/b1 /dir`  
-Healing /dir failed:Operation not permitted.  
-Volume heal failed.  
+
+```console
+# gluster volume heal test split-brain source-brick test-host:/test/b1 /dir
+Healing /dir failed:Operation not permitted.
+Volume heal failed.
+```
 
 However, they can be fixed by deleting the file from all but one bricks. See [Fixing Directory entry split-brain](#dir-split-brain)
 
@@ -289,9 +338,9 @@ A set of getfattr and setfattr commands have been provided to detect the data an
 
 Consider a volume "test", having bricks b0, b1, b2 and b3.
 
-~~~
+```console
 # gluster volume info test
- 
+
 Volume Name: test
 Type: Distributed-Replicate
 Volume ID: 00161935-de9e-4b80-a643-b36693183b61
@@ -303,11 +352,11 @@ Brick1: test-host:/test/b0
 Brick2: test-host:/test/b1
 Brick3: test-host:/test/b2
 Brick4: test-host:/test/b3
-~~~
+```
 
 Directory structure of the bricks is as follows:
 
-~~~
+```console
 # tree -R /test/b?
 /test/b0
 ├── dir
@@ -330,10 +379,11 @@ Directory structure of the bricks is as follows:
 ├── file1
 ├── file2
 └── file99
-~~~
+```
 
 Some files in the volume are in split-brain.
-~~~
+
+```console
 # gluster v heal test info split-brain
 Brick test-host:/test/b0/
 /file100
@@ -354,75 +404,91 @@ Brick test-host:/test/b3/
 <gfid:05c4b283-af58-48ed-999e-4d706c7b97d5>
 <gfid:5399a8d1-aee9-4653-bb7f-606df02b3696>
 Number of entries in split-brain: 2
-~~~
+```
+
 ### To know data/metadata split-brain status of a file:
-~~~
+
+```console
 getfattr -n replica.split-brain-status <path-to-file>
-~~~
+```
+
 The above command executed from mount provides information if a file is in data/metadata split-brain. Also provides the list of afr children to analyze to get more information about the file.
 This command is not applicable to gfid/directory split-brain.
 
 ### Example:
 1) "file100" is in metadata split-brain. Executing the above mentioned command for file100 gives :
-~~~
+
+```console
 # getfattr -n replica.split-brain-status file100
-# file: file100
+file: file100
 replica.split-brain-status="data-split-brain:no    metadata-split-brain:yes    Choices:test-client-0,test-client-1"
-~~~
+```
 
 2) "file1" is in data split-brain.
-~~~
+
+```console
 # getfattr -n replica.split-brain-status file1
-# file: file1
+file: file1
 replica.split-brain-status="data-split-brain:yes    metadata-split-brain:no    Choices:test-client-2,test-client-3"
-~~~
+```
 
 3) "file99" is in both data and metadata split-brain.
-~~~
+
+```console
 # getfattr -n replica.split-brain-status file99
-# file: file99
+file: file99
 replica.split-brain-status="data-split-brain:yes    metadata-split-brain:yes    Choices:test-client-2,test-client-3"
-~~~
+```
 
 4) "dir" is in directory split-brain but as mentioned earlier, the above command is not applicable to such split-brain. So it says that the file is not under data or metadata split-brain.
-~~~
+
+```console
 # getfattr -n replica.split-brain-status dir
-# file: dir
+file: dir
 replica.split-brain-status="The file is not under data or metadata split-brain"
-~~~
+```
 
 5) "file2" is not in any kind of split-brain.
-~~~
+
+```console
 # getfattr -n replica.split-brain-status file2
-# file: file2
+file: file2
 replica.split-brain-status="The file is not under data or metadata split-brain"
-~~~
+```
 
 ### To analyze the files in data and metadata split-brain
 Trying to do operations (say cat, getfattr etc) from the mount on files in split-brain, gives an input/output error. To enable the users analyze such files, a setfattr command is provided.
 
-~~~
+```console
 # setfattr -n replica.split-brain-choice -v "choiceX" <path-to-file>
-~~~
+```
+
 Using this command, a particular brick can be chosen to access the file in split-brain from.
 
-###Example:
+### Example:
+
 1) "file1" is in data-split-brain. Trying to read from the file gives input/output error.
-~~~
+
+```console
 # cat file1
 cat: file1: Input/output error
-~~~
+```
+
 Split-brain choices provided for file1 were test-client-2 and test-client-3.
 
 Setting test-client-2 as split-brain choice for file1 serves reads from b2 for the file.
-~~~
+
+```console
 # setfattr -n replica.split-brain-choice -v test-client-2 file1
-~~~
+```
+
 Now, read operations on the file can be done.
-~~~
+
+```console
 # cat file1
 xyz
-~~~
+```
+
 Similarly, to inspect the file from other choice, replica.split-brain-choice is to be set to test-client-3.
 
 Trying to inspect the file from a wrong choice errors out.
@@ -431,45 +497,52 @@ To undo the split-brain-choice that has been set, the above mentioned setfattr c
 with "none" as the value for extended attribute.
 
 ### Example:
-~~~
-1) setfattr -n replica.split-brain-choice -v none file1
-~~~
+
+```console
+# setfattr -n replica.split-brain-choice -v none file1
+```
+
 Now performing cat operation on the file will again result in input/output error, as before.
-~~~
+
+```console
 # cat file
 cat: file1: Input/output error
-~~~
+```
 
 Once the choice for resolving split-brain is made, source brick is supposed to be set for the healing to be done.
 This is done using the following command:
 
-~~~
-#  setfattr -n replica.split-brain-heal-finalize -v <heal-choice> <path-to-file>
-~~~
+```console
+# setfattr -n replica.split-brain-heal-finalize -v <heal-choice> <path-to-file>
+```
 
 ## Example
-~~~
+
+```console
 # setfattr -n replica.split-brain-heal-finalize -v test-client-2 file1
-~~~
+```
+
 The above process can be used to resolve data and/or metadata split-brain on all the files.
 
-NOTE:  
+**NOTE**:
+
 1) If "fopen-keep-cache" fuse mount option is disabled then inode needs to be invalidated each time before selecting a new replica.split-brain-choice to inspect a file. This can be done by using:
-~~~
+
+```console
 # sefattr -n inode-invalidate -v 0 <path-to-file>
-~~~
+```
 
 2) The above mentioned process for split-brain resolution from mount will not work on nfs mounts as it doesn't provide xattrs support.
 
 # 5. Automagic unsplit-brain by [ctime|mtime|size|majority]
 The CLI and fuse mount based resolution methods require intervention in the sense that the admin/ user needs to run the commands manually. There is a   `cluster.favorite-child-policy` volume option which when set to one of the various policies available, automatically resolve split-brains without user intervention. The default value is 'none', i.e. it is disabled.
 
-~~~~
-gluster volume set help|grep -A3 cluster.favorite-child-policy
+```console
+# gluster volume set help | grep -A3 cluster.favorite-child-policy
 Option: cluster.favorite-child-policy
 Default Value: none
 Description: This option can be used to automatically resolve split-brains using various policies without user intervention. "size" picks the file with the biggest size as the source. "ctime" and "mtime" pick the file with the latest ctime and mtime respectively as the source. "majority" picks a file with identical mtime and size in more than half the number of bricks in the replica.
-~~~~
+```
 
 `cluster.favorite-child-policy` applies to all files of the volume. It is assumed that if this option is enabled with a particular policy, you don't care to examine the split-brain files on a per file basis but just want the split-brain to be resolved as and when it occurs based on the set policy.
 
@@ -512,13 +585,16 @@ afr changelog extended attributes.
 
 Execute `getfattr -d -m . -e hex <file-path-on-brick>`
 
-* Example:  
-[root@store3 ~]# getfattr -d -e hex -m. brick-a/file.txt  
-\#file: brick-a/file.txt  
-security.selinux=0x726f6f743a6f626a6563745f723a66696c655f743a733000  
-trusted.afr.vol-client-2=0x000000000000000000000000  
-trusted.afr.vol-client-3=0x000000000200000000000000  
-trusted.gfid=0x307a5c9efddd4e7c96e94fd4bcdcbd1b  
+Example:
+
+```console
+[root@store3 ~]# getfattr -d -e hex -m. brick-a/file.txt
+\#file: brick-a/file.txt
+security.selinux=0x726f6f743a6f626a6563745f723a66696c655f743a733000
+trusted.afr.vol-client-2=0x000000000000000000000000
+trusted.afr.vol-client-3=0x000000000200000000000000
+trusted.gfid=0x307a5c9efddd4e7c96e94fd4bcdcbd1b
+```
 
 The extended attributes with `trusted.afr.<volname>-client-<subvolume-index>`
 are used by afr to maintain changelog of the file.The values of the
@@ -530,26 +606,30 @@ attribute according to the response of the brick.
 'subvolume-index' is nothing but (brick number - 1) in
 `gluster volume info <volname>` output.
 
-* Example:  
-[root@pranithk-laptop ~]# gluster volume info vol  
- Volume Name: vol  
- Type: Distributed-Replicate  
- Volume ID: 4f2d7849-fbd6-40a2-b346-d13420978a01  
- Status: Created  
- Number of Bricks: 4 x 2 = 8  
- Transport-type: tcp  
- Bricks:  
- brick-a: pranithk-laptop:/gfs/brick-a  
- brick-b: pranithk-laptop:/gfs/brick-b  
- brick-c: pranithk-laptop:/gfs/brick-c  
- brick-d: pranithk-laptop:/gfs/brick-d  
- brick-e: pranithk-laptop:/gfs/brick-e  
- brick-f: pranithk-laptop:/gfs/brick-f  
- brick-g: pranithk-laptop:/gfs/brick-g  
- brick-h: pranithk-laptop:/gfs/brick-h  
+Example:
 
-In the example above:  
+```console
+[root@pranithk-laptop ~]# gluster volume info vol
+ Volume Name: vol
+ Type: Distributed-Replicate
+ Volume ID: 4f2d7849-fbd6-40a2-b346-d13420978a01
+ Status: Created
+ Number of Bricks: 4 x 2 = 8
+ Transport-type: tcp
+ Bricks:
+ brick-a: pranithk-laptop:/gfs/brick-a
+ brick-b: pranithk-laptop:/gfs/brick-b
+ brick-c: pranithk-laptop:/gfs/brick-c
+ brick-d: pranithk-laptop:/gfs/brick-d
+ brick-e: pranithk-laptop:/gfs/brick-e
+ brick-f: pranithk-laptop:/gfs/brick-f
+ brick-g: pranithk-laptop:/gfs/brick-g
+ brick-h: pranithk-laptop:/gfs/brick-h
 ```
+
+In the example above:
+
+```console
 Brick             |    Replica set        |    Brick subvolume index
 ----------------------------------------------------------------------------
 -/gfs/brick-a     |       0               |       0
@@ -582,14 +662,15 @@ First 8 digits represent changelog of data. Second 8 digits represent changelog
 of metadata. Last 8 digits represent Changelog of directory entries.  
 
 Pictorially representing the same, we have:
-```
+
+```text
 0x 000003d7 00000001 00000000
         |      |       |
         |      |        \_ changelog of directory entries
         |       \_ changelog of metadata
          \ _ changelog of data
 ```
-         
+
 
 For Directories metadata and entry changelogs are valid.
 For regular files data and metadata changelogs are valid.
@@ -598,21 +679,25 @@ When a file split-brain happens it could be either data split-brain or
 meta-data split-brain or both. When a split-brain happens the changelog of the
 file would be something like this:  
 
-* Example:(Lets consider both data, metadata split-brain on same file).  
-[root@pranithk-laptop vol]# getfattr -d -m . -e hex /gfs/brick-?/a  
-getfattr: Removing leading '/' from absolute path names  
-\#file: gfs/brick-a/a  
-trusted.afr.vol-client-0=0x000000000000000000000000  
-trusted.afr.vol-client-1=0x000003d70000000100000000  
-trusted.gfid=0x80acdbd886524f6fbefa21fc356fed57   
-\#file: gfs/brick-b/a  
-trusted.afr.vol-client-0=0x000003b00000000100000000  
-trusted.afr.vol-client-1=0x000000000000000000000000  
-trusted.gfid=0x80acdbd886524f6fbefa21fc356fed57  
+Example:(Lets consider both data, metadata split-brain on same file).
 
-###Observations:
+```console
+[root@pranithk-laptop vol]# getfattr -d -m . -e hex /gfs/brick-?/a
+getfattr: Removing leading '/' from absolute path names
+\#file: gfs/brick-a/a
+trusted.afr.vol-client-0=0x000000000000000000000000
+trusted.afr.vol-client-1=0x000003d70000000100000000
+trusted.gfid=0x80acdbd886524f6fbefa21fc356fed57
+\#file: gfs/brick-b/a
+trusted.afr.vol-client-0=0x000003b00000000100000000
+trusted.afr.vol-client-1=0x000000000000000000000000
+trusted.gfid=0x80acdbd886524f6fbefa21fc356fed57
+```
 
-####According to changelog extended attributes on file /gfs/brick-a/a:  
+### Observations:
+
+#### According to changelog extended attributes on file /gfs/brick-a/a:
+
 The first 8 digits of trusted.afr.vol-client-0 are all
 zeros (0x00000000................), and the first 8 digits of
 trusted.afr.vol-client-1 are not all zeros (0x000003d7................).
@@ -625,7 +710,8 @@ trusted.afr.vol-client-1 are not all zeros (0x........00000001........).
 So the changelog on /gfs/brick-a/a implies that some metadata operations succeeded 
 on itself but failed on /gfs/brick-b/a.
 
-####According to Changelog extended attributes on file /gfs/brick-b/a:  
+#### According to Changelog extended attributes on file /gfs/brick-b/a:
+
 The first 8 digits of trusted.afr.vol-client-0 are not all
 zeros (0x000003b0................), and the first 8 digits of
 trusted.afr.vol-client-1 are all zeros (0x00000000................).
@@ -641,23 +727,25 @@ on itself but failed on /gfs/brick-a/a.
 Since both the copies have data, metadata changes that are not on the other
 file, it is in both data and metadata split-brain.
 
-Deciding on the correct copy:  
------------------------------
+#### Deciding on the correct copy:
+
 The user may have to inspect stat,getfattr output of the files to decide which 
 metadata to retain and contents of the file to decide which data to retain.
 Continuing with the example above, lets say we want to retain the data
 of /gfs/brick-a/a and metadata of /gfs/brick-b/a.
 
-Resetting the relevant changelogs to resolve the split-brain:  
--------------------------------------------------------------
-For resolving data-split-brain:  
+#### Resetting the relevant changelogs to resolve the split-brain:  
+
+For resolving data-split-brain:
+
 We need to change the changelog extended attributes on the files as if some data
 operations succeeded on /gfs/brick-a/a but failed on /gfs/brick-b/a. But
 /gfs/brick-b/a should NOT have any changelog which says some data operations
 succeeded on /gfs/brick-b/a but failed on /gfs/brick-a/a. We need to reset the
 data part of the changelog on trusted.afr.vol-client-0 of /gfs/brick-b/a.
 
-For resolving metadata-split-brain:  
+For resolving metadata-split-brain:
+
 We need to change the changelog extended attributes on the files as if some
 metadata operations succeeded on /gfs/brick-b/a but failed on /gfs/brick-a/a.
 But /gfs/brick-a/a should NOT have any changelog which says some metadata

--- a/docs/Troubleshooting/statedump.md
+++ b/docs/Troubleshooting/statedump.md
@@ -14,22 +14,26 @@ A statedump is, as the name suggests, a dump of the internal state of a glusterf
 ## Generate a Statedump
 Run the command
 
-                gluster --print-statedumpdir
+```console
+# gluster --print-statedumpdir
+```
 
 on a gluster server node to find out which directory the statedumps will be created in. This directory may need to be created if not already present.
 For the rest of this document, we will refer to this directory as `statedump-directory`.
 
 To generate a statedump for a process, run
 
-                kill -USR1 <pid-of-gluster-process>
-
+```console
+kill -USR1 <pid-of-gluster-process>
+```
 
 For client mounts:
 
 Run the following command on the client system
 
-                kill -USR1 <pid-of-gluster-mount-process>
-
+```console
+kill -USR1 <pid-of-gluster-mount-process>
+```
 
 There are specific commands to generate statedumps for all brick processes/nfs server/quotad which can be used instead of the above. Run the following
 commands on one of the server nodes:
@@ -37,16 +41,21 @@ commands on one of the server nodes:
 
 For bricks:
 
-                gluster volume statedump <volname>
+```console
+gluster volume statedump <volname>
+```
 
 For the NFS server:
 
-                gluster volume statedump <volname> nfs
+```console
+gluster volume statedump <volname> nfs
+```
 
 For quotad:
 
-                gluster volume statedump <volname> quotad
-
+```console
+gluster volume statedump <volname> quotad
+```
 
 The statedumps will be created in `statedump-directory` on each node. The statedumps for brick processes will be created with the filename `hyphenated-brick-path.<pid>.dump.timestamp` while for all other processes it will be `glusterdump.<pid>.dump.timestamp`.
 
@@ -77,6 +86,7 @@ mallinfo_keepcost=133712    /* Top-most, releasable space (bytes) */
 Each xlator defines data structures specific to its requirements. The statedump captures information about the memory usage and allocations of these structures for each xlator in the call-stack and prints them in the following format:
 
 For the xlator with the name _glusterfs_
+
 ```
 [global.glusterfs - Memory usage]   #[global.<xlator-name> - Memory usage]
 num_types=119                       #The number of data types it is using
@@ -121,6 +131,7 @@ This information is also useful while debugging high memory usage issues as larg
 
 
 ### Iobufs
+
 ```
 [iobuf.global]
 iobuf_pool=0x1f0d970                #The memory pool for iobufs
@@ -156,6 +167,7 @@ arena.5.page_size=32768
 ```
 
 If the active_cnt of any arena is non zero, then the statedump will also have the iobuf list.
+
 ```
 [arena.6.active_iobuf.1]                  #arena.<S.No>.active_iobuf.<iobuf.S.No.>
 arena.6.active_iobuf.1.ref=1              #refcount of the iobuf
@@ -221,6 +233,7 @@ message=[0] fuse_getattr_resume: 4591, STAT, path: (/iozone.tmp), gfid: (3afb496
 ```
 
 ### Xlator configuration
+
 ```
 [cluster/replicate.r2-replicate-0] #Xlator type, name information
 child_count=2                      #Number of children for the xlator
@@ -241,6 +254,7 @@ wait_count=1
 ```
 
 ### Graph/inode table
+
 ```
 [active graph - 1]
 
@@ -253,6 +267,7 @@ conn.1.bound_xl./data/brick01a/homegfs.purge_size=0    #Number of inodes present
 ```
 
 ### Inode
+
 ```
 [conn.1.bound_xl./data/brick01a/homegfs.active.324] #324th inode in active inode list
 gfid=e6d337cf-97eb-44b3-9492-379ba3f6ad42           #Gfid of the inode
@@ -271,6 +286,7 @@ ia_type=2
 
 ### Inode context
 Each xlator can store information specific to it in the inode context. This context can also be printed in the statedump. Here is the inode context of the locks xlator
+
 ```
 [xlator.features.locks.homegfs-locks.inode]
 path=/homegfs/users/dfrobins/gfstest/r4/SCRATCH/fort.5102 - path of the file
@@ -301,7 +317,9 @@ The following examples walk through using statedumps to debug two different memo
 
 A statedump of the self heal daemon process was taken using 
 
-                kill -USR1 `<pid-of-gluster-self-heal-daemon>`
+```console
+kill -USR1 `<pid-of-gluster-self-heal-daemon>`
+```
 
 On examining the statedump:
 

--- a/docs/Troubleshooting/troubleshooting-filelocks.md
+++ b/docs/Troubleshooting/troubleshooting-filelocks.md
@@ -13,7 +13,7 @@ lock using the following `clear lock` commands.
 1.  **Perform statedump on the volume to view the files that are locked
     using the following command:**
 
-    `# gluster volume statedump  inode`
+        # gluster volume statedump  inode
 
     For example, to display statedump of test-volume:
 
@@ -58,7 +58,7 @@ lock using the following `clear lock` commands.
 
 2.  **Clear the lock using the following command:**
 
-    `# gluster volume clear-locks`
+        # gluster volume clear-locks
 
     For example, to clear the entry lock on `file1` of test-volume:
 
@@ -68,7 +68,7 @@ lock using the following `clear lock` commands.
 
 3.  **Clear the inode lock using the following command:**
 
-    `# gluster volume clear-locks`
+        # gluster volume clear-locks
 
     For example, to clear the inode lock on `file1` of test-volume:
 

--- a/docs/Troubleshooting/troubleshooting-georep.md
+++ b/docs/Troubleshooting/troubleshooting-georep.md
@@ -21,11 +21,15 @@ associated to it (four, if the slave is a gluster volume):
 To get the Master-log-file for geo-replication, use the following
 command:
 
-`gluster volume geo-replication  config log-file`
+```console
+gluster volume geo-replication <session> config log-file
+```
 
 For example:
 
-`# gluster volume geo-replication Volume1 example.com:/data/remote_dir config log-file `
+```console
+# gluster volume geo-replication Volume1 example.com:/data/remote_dir config log-file
+```
 
 **Slave Log File**
 
@@ -34,18 +38,18 @@ running on slave machine), use the following commands:
 
 1.  On master, run the following command:
 
-    `# gluster volume geo-replication Volume1 example.com:/data/remote_dir config session-owner 5f6e5200-756f-11e0-a1f0-0800200c9a66 `
+        # gluster volume geo-replication Volume1 example.com:/data/remote_dir config session-owner 5f6e5200-756f-11e0-a1f0-0800200c9a66
 
     Displays the session owner details.
 
 2.  On slave, run the following command:
 
-    `# gluster volume geo-replication /data/remote_dir config log-file /var/log/gluster/${session-owner}:remote-mirror.log `
+        # gluster volume geo-replication /data/remote_dir config log-file /var/log/gluster/${session-owner}:remote-mirror.log
 
 3.  Replace the session owner details (output of Step 1) to the output
     of Step 2 to get the location of the log file.
 
-    `/var/log/gluster/5f6e5200-756f-11e0-a1f0-0800200c9a66:remote-mirror.log`
+        /var/log/gluster/5f6e5200-756f-11e0-a1f0-0800200c9a66:remote-mirror.log
 
 ### Rotating Geo-replication Logs
  
@@ -60,7 +64,7 @@ log file.
 -   Rotate log file for a particular master-slave session using the
     following command:
 
-    `# gluster volume geo-replication  log-rotate`
+        # gluster volume geo-replication  log-rotate
 
     For example, to rotate the log file of master `Volume1` and slave
     `example.com:/data/remote_dir` :
@@ -71,7 +75,7 @@ log file.
 -   Rotate log file for all sessions for a master volume using the
     following command:
 
-    `# gluster volume geo-replication  log-rotate`
+        # gluster volume geo-replication  log-rotate
 
     For example, to rotate the log file of master `Volume1`:
 
@@ -80,7 +84,7 @@ log file.
 
 -   Rotate log file for all sessions using the following command:
 
-    `# gluster volume geo-replication log-rotate`
+        # gluster volume geo-replication log-rotate
 
     For example, to rotate the log file for all sessions:
 
@@ -105,8 +109,10 @@ utilization operation on large data sets.
 not get synced, only directories and symlink gets synced with the
 following error message in the log:
 
-    [2011-05-02 13:42:13.467644] E [master:288:regjob] GMaster: failed to
-    sync ./some\_file\`
+```console
+[2011-05-02 13:42:13.467644] E [master:288:regjob] GMaster: failed to
+sync ./some\_file\`
+```
 
 **Solution**: Geo-replication invokes rsync v3.0.0 or higher on the host
 and the remote machine. You must verify if you have installed the
@@ -117,14 +123,16 @@ required version.
 **Description**: Geo-replication displays status as faulty very often
 with a backtrace similar to the following:
 
-    2011-04-28 14:06:18.378859] E [syncdutils:131:log\_raise\_exception]
-    \<top\>: FAIL: Traceback (most recent call last): File
-    "/usr/local/libexec/glusterfs/python/syncdaemon/syncdutils.py", line
-    152, in twraptf(\*aa) File
-    "/usr/local/libexec/glusterfs/python/syncdaemon/repce.py", line 118, in
-    listen rid, exc, res = recv(self.inf) File
-    "/usr/local/libexec/glusterfs/python/syncdaemon/repce.py", line 42, in
-    recv return pickle.load(inf) EOFError
+```console
+2011-04-28 14:06:18.378859] E [syncdutils:131:log\_raise\_exception]
+\<top\>: FAIL: Traceback (most recent call last): File
+"/usr/local/libexec/glusterfs/python/syncdaemon/syncdutils.py", line
+152, in twraptf(\*aa) File
+"/usr/local/libexec/glusterfs/python/syncdaemon/repce.py", line 118, in
+listen rid, exc, res = recv(self.inf) File
+"/usr/local/libexec/glusterfs/python/syncdaemon/repce.py", line 42, in
+recv return pickle.load(inf) EOFError
+```
 
 **Solution**: This error indicates that the RPC communication between
 the master gsyncd module and slave gsyncd module is broken and this can
@@ -152,9 +160,11 @@ pre-requisites:
 **Description**: In a cascading set-up, the intermediate master goes to
 faulty state with the following log:
 
-    raise RuntimeError ("aborting on uuid change from %s to %s" % \\
-    RuntimeError: aborting on uuid change from af07e07c-427f-4586-ab9f-
-    4bf7d299be81 to de6b5040-8f4e-4575-8831-c4f55bd41154
+```console
+raise RuntimeError ("aborting on uuid change from %s to %s" % \\
+RuntimeError: aborting on uuid change from af07e07c-427f-4586-ab9f-
+4bf7d299be81 to de6b5040-8f4e-4575-8831-c4f55bd41154
+```
 
 **Solution**: In a cascading set-up the Intermediate master is loyal to
 the original primary master. The above log means that the

--- a/docs/Troubleshooting/troubleshooting-glusterd.md
+++ b/docs/Troubleshooting/troubleshooting-glusterd.md
@@ -59,15 +59,18 @@ would need to access that brick may fail with "Transport endpoint is not connect
 
 `gluster peer status` returns "Peer Rejected" for a node.
 
-	Hostname: <hostname>
-	Uuid: <xxxx-xxx-xxxx>
-	State: Peer Rejected (Connected)
-
+```console
+Hostname: <hostname>
+Uuid: <xxxx-xxx-xxxx>
+State: Peer Rejected (Connected)
+```
 
 This indicates that the volume configuration on the node is not in sync with the rest of the trusted storage pool. 
 You should see the following message in the glusterd log for the node on which the peer status command was run:
 
-_Version of Cksums <vol-name> differ. local cksum = xxxxxx, remote cksum = xxxxyx on peer <hostname>_
+```console
+Version of Cksums <vol-name> differ. local cksum = xxxxxx, remote cksum = xxxxyx on peer <hostname>
+```
 
 *Solution*: Update the cluster.op-version
 
@@ -79,14 +82,14 @@ _Version of Cksums <vol-name> differ. local cksum = xxxxxx, remote cksum = xxxxy
 **"Accepted Peer Request"**
 
 If the glusterd handshake fails while expanding a cluster, the view of the cluster will be inconsistent. The state of the peer in `gluster peer status` will be  “accepted peer request” and subsequent CLI commands will fail with an error.
-Eg. "Volume create command will fail with "volume create: testvol: failed: Host <hostname> is not in 'Peer in Cluster' state 
+Eg. `Volume create command will fail with "volume create: testvol: failed: Host <hostname> is not in 'Peer in Cluster' state` 
     
-In this case the value of the state field in /var/lib/glusterd/peers/<UUID> will be other than 3.
+In this case the value of the state field in `/var/lib/glusterd/peers/<UUID>` will be other than 3.
 
 *Solution*:
 
 * Stop glusterd
-* Open /var/lib/glusterd/peers/<UUID>
+* Open `/var/lib/glusterd/peers/<UUID>`
 * Change state to 3
 * Start glusterd
 

--- a/docs/Troubleshooting/troubleshooting-gnfs.md
+++ b/docs/Troubleshooting/troubleshooting-gnfs.md
@@ -5,17 +5,21 @@ NFS .
 
 ### mount command on NFS client fails with “RPC Error: Program not registered”
 
-    Start portmap or rpcbind service on the NFS server.
+Start portmap or rpcbind service on the NFS server.
 
 This error is encountered when the server has not started correctly.
 On most Linux distributions this is fixed by starting portmap:
 
-`$ /etc/init.d/portmap start`
+```console
+# /etc/init.d/portmap start
+```
 
 On some distributions where portmap has been replaced by rpcbind, the
 following command is required:
 
-`$ /etc/init.d/rpcbind start `
+```console
+# /etc/init.d/rpcbind start
+```
 
 After starting portmap or rpcbind, gluster NFS server needs to be
 restarted.
@@ -28,13 +32,15 @@ This error can arise in case there is already a Gluster NFS server
 running on the same machine. This situation can be confirmed from the
 log file, if the following error lines exist:
 
-    [2010-05-26 23:40:49] E [rpc-socket.c:126:rpcsvc_socket_listen] rpc-socket: binding socket failed:Address already in use
-    [2010-05-26 23:40:49] E [rpc-socket.c:129:rpcsvc_socket_listen] rpc-socket: Port is already in use 
-    [2010-05-26 23:40:49] E [rpcsvc.c:2636:rpcsvc_stage_program_register] rpc-service: could not create listening connection 
-    [2010-05-26 23:40:49] E [rpcsvc.c:2675:rpcsvc_program_register] rpc-service: stage registration of program failed 
-    [2010-05-26 23:40:49] E [rpcsvc.c:2695:rpcsvc_program_register] rpc-service: Program registration failed: MOUNT3, Num: 100005, Ver: 3, Port: 38465 
-    [2010-05-26 23:40:49] E [nfs.c:125:nfs_init_versions] nfs: Program init failed 
-    [2010-05-26 23:40:49] C [nfs.c:531:notify] nfs: Failed to initialize protocols
+```text
+[2010-05-26 23:40:49] E [rpc-socket.c:126:rpcsvc_socket_listen] rpc-socket: binding socket failed:Address already in use
+[2010-05-26 23:40:49] E [rpc-socket.c:129:rpcsvc_socket_listen] rpc-socket: Port is already in use 
+[2010-05-26 23:40:49] E [rpcsvc.c:2636:rpcsvc_stage_program_register] rpc-service: could not create listening connection 
+[2010-05-26 23:40:49] E [rpcsvc.c:2675:rpcsvc_program_register] rpc-service: stage registration of program failed 
+[2010-05-26 23:40:49] E [rpcsvc.c:2695:rpcsvc_program_register] rpc-service: Program registration failed: MOUNT3, Num: 100005, Ver: 3, Port: 38465 
+[2010-05-26 23:40:49] E [nfs.c:125:nfs_init_versions] nfs: Program init failed 
+[2010-05-26 23:40:49] C [nfs.c:531:notify] nfs: Failed to initialize protocols
+```
 
 To resolve this error one of the Gluster NFS servers will have to be
 shutdown. At this time, Gluster NFS server does not support running
@@ -44,13 +50,17 @@ multiple NFS servers on the same machine.
 
 If the mount command fails with the following error message:
 
-    mount.nfs: rpc.statd is not running but is required for remote locking.
-    mount.nfs: Either use '-o nolock' to keep locks local, or start statd.
+```console
+mount.nfs: rpc.statd is not running but is required for remote locking.
+mount.nfs: Either use '-o nolock' to keep locks local, or start statd.
+```
 
 For NFS clients to mount the NFS server, rpc.statd service must be
 running on the clients. Start rpc.statd service by running the following command:
 
-`$ rpc.statd `
+```console
+# rpc.statd
+```
 
 ### mount command takes too long to finish.
 
@@ -60,12 +70,16 @@ The problem is that the rpcbind or portmap service is not running on the
 NFS client. The resolution for this is to start either of these services
 by running the following command:
 
-`$ /etc/init.d/portmap start`
+```console
+# /etc/init.d/portmap start
+```
 
 On some distributions where portmap has been replaced by rpcbind, the
 following command is required:
 
-`$ /etc/init.d/rpcbind start`
+```console
+# /etc/init.d/rpcbind start
+```
 
 ### NFS server glusterfsd starts but initialization fails with “nfsrpc- service: portmap registration of program failed” error message in the log.
 
@@ -74,26 +88,28 @@ still fail preventing clients from accessing the mount points. Such a
 situation can be confirmed from the following error messages in the log
 file:
 
-    [2010-05-26 23:33:47] E [rpcsvc.c:2598:rpcsvc_program_register_portmap] rpc-service: Could notregister with portmap 
-    [2010-05-26 23:33:47] E [rpcsvc.c:2682:rpcsvc_program_register] rpc-service: portmap registration of program failed
-    [2010-05-26 23:33:47] E [rpcsvc.c:2695:rpcsvc_program_register] rpc-service: Program registration failed: MOUNT3, Num: 100005, Ver: 3, Port: 38465
-    [2010-05-26 23:33:47] E [nfs.c:125:nfs_init_versions] nfs: Program init failed
-    [2010-05-26 23:33:47] C [nfs.c:531:notify] nfs: Failed to initialize protocols
-    [2010-05-26 23:33:49] E [rpcsvc.c:2614:rpcsvc_program_unregister_portmap] rpc-service: Could not unregister with portmap
-    [2010-05-26 23:33:49] E [rpcsvc.c:2731:rpcsvc_program_unregister] rpc-service: portmap unregistration of program failed
-    [2010-05-26 23:33:49] E [rpcsvc.c:2744:rpcsvc_program_unregister] rpc-service: Program unregistration failed: MOUNT3, Num: 100005, Ver: 3, Port: 38465
+```text
+[2010-05-26 23:33:47] E [rpcsvc.c:2598:rpcsvc_program_register_portmap] rpc-service: Could notregister with portmap 
+[2010-05-26 23:33:47] E [rpcsvc.c:2682:rpcsvc_program_register] rpc-service: portmap registration of program failed
+[2010-05-26 23:33:47] E [rpcsvc.c:2695:rpcsvc_program_register] rpc-service: Program registration failed: MOUNT3, Num: 100005, Ver: 3, Port: 38465
+[2010-05-26 23:33:47] E [nfs.c:125:nfs_init_versions] nfs: Program init failed
+[2010-05-26 23:33:47] C [nfs.c:531:notify] nfs: Failed to initialize protocols
+[2010-05-26 23:33:49] E [rpcsvc.c:2614:rpcsvc_program_unregister_portmap] rpc-service: Could not unregister with portmap
+[2010-05-26 23:33:49] E [rpcsvc.c:2731:rpcsvc_program_unregister] rpc-service: portmap unregistration of program failed
+[2010-05-26 23:33:49] E [rpcsvc.c:2744:rpcsvc_program_unregister] rpc-service: Program unregistration failed: MOUNT3, Num: 100005, Ver: 3, Port: 38465
+```
 
 1.  **Start portmap or rpcbind service on the NFS server**
 
     On most Linux distributions, portmap can be started using the
     following command:
 
-    `$ /etc/init.d/portmap start `
+        # /etc/init.d/portmap start
 
     On some distributions where portmap has been replaced by rpcbind,
     run the following command:
 
-    `$ /etc/init.d/rpcbind start `
+        # /etc/init.d/rpcbind start
 
     After starting portmap or rpcbind, gluster NFS server needs to be
     restarted.
@@ -110,9 +126,8 @@ file:
     On Linux, kernel NFS servers can be stopped by using either of the
     following commands depending on the distribution in use:
 
-    `$ /etc/init.d/nfs-kernel-server stop`
-
-    `$ /etc/init.d/nfs stop`
+        # /etc/init.d/nfs-kernel-server stop
+        # /etc/init.d/nfs stop
 
 3.  **Restart Gluster NFS server**
 
@@ -120,7 +135,9 @@ file:
 
 mount command fails with following error
 
-    *mount: mount to NFS server '10.1.10.11' failed: timed out (retrying).*
+```console
+mount: mount to NFS server '10.1.10.11' failed: timed out (retrying).
+```
 
 Perform one of the following to resolve this issue:
 
@@ -158,7 +175,7 @@ Perform one of the following to resolve this issue:
     forcing the NFS client to use version 3. The **vers** option to
     mount command is used for this purpose:
 
-    `$ mount  -o vers=3 `
+        # mount  -o vers=3
 
 ### showmount fails with clnt\_create: RPC: Unable to receive
 
@@ -186,4 +203,6 @@ by default.
 Applications which can be rebuilt from source are recommended to rebuild
 using the following flag with gcc:
 
-` -D_FILE_OFFSET_BITS=64`
+```
+-D_FILE_OFFSET_BITS=64
+```

--- a/docs/Upgrade-Guide/op_version.md
+++ b/docs/Upgrade-Guide/op_version.md
@@ -12,22 +12,30 @@ Current op-version can be queried as below:
 
 For 3.10 onwards:
 
-    [root@~]#gluster volume get all cluster.op-version
+```console
+# gluster volume get all cluster.op-version
+```
 
 For release < 3.10:
 
-    [root@~]#gluster volume get <VOLNAME> cluster.op-version
+```console
+# gluster volume get <VOLNAME> cluster.op-version
+```
 
 To get the maximum possible op-version a cluster can support, the following query can be used (this is available 3.10 release onwards):
 
-    [root@~]#gluster volume get all cluster.max-op-version
+```console
+# gluster volume get all cluster.max-op-version
+```
 
 For example, if some nodes in a cluster have been upgraded to X and some to X+, then the maximum op-version supported by the cluster is X, and the cluster.op-version can be bumped up to X to support new features.
 
 op-version can be updated as below.
 For example, after upgrading to glusterfs-4.0.0, set op-version as:
 
-    [root@~]#gluster volume set all cluster.op-version 40000
+```console
+# gluster volume set all cluster.op-version 40000
+```
 
 Note:
 This is not mandatory, but advisable to have updated op-version if you want to make use of latest features in the updated gluster.
@@ -38,7 +46,9 @@ When trying to set a volume option, it might happen that one or more of the conn
 
 To check op-version information for the connected clients and find the offending client, the following query can be used for 3.10 release onwards:
 
-    [root@~]#gluster volume status <all|VOLNAME> clients
+```console
+# gluster volume status <all|VOLNAME> clients
+```
 
 The respective clients can then be upgraded to the required version.
 

--- a/docs/Upgrade-Guide/upgrade_to_3.12.md
+++ b/docs/Upgrade-Guide/upgrade_to_3.12.md
@@ -17,47 +17,41 @@ This procedure involves upgrading **one server at a time**, while keeping the vo
 
 #### Repeat the following steps, on each server in the trusted storage pool, to upgrade the entire pool to 3.12 version:
 1. Stop all gluster services, either using the command below, or through other means,
-```sh
-    #killall glusterfs glusterfsd glusterd
-    #systemctl stop glustereventsd
-```
+
+        # killall glusterfs glusterfsd glusterd
+        # systemctl stop glustereventsd
 
 2. Stop all applications that run on this server and access the volumes via gfapi (qemu, NFS-Ganesha, Samba, etc.)
 
 3. Install Gluster 3.12
 
 4. Ensure that version reflects 3.12.x in the output of,
-```sh
-    #gluster --version
-```
 
-> **NOTE:** x is the minor release number for the release
+        # gluster --version
+
+    > **NOTE:** x is the minor release number for the release
 
 5. Start glusterd on the upgraded server
-```sh
-    #glusterd
-```
+
+        # glusterd
 
 6. Ensure that all gluster processes are online by checking the output of,
-```sh
-    #gluster volume status
-```
+
+        # gluster volume status
 
 7. If the glustereventsd service was previously enabled, it is required to start it using the commands below, or, through other means,
-```sh
-    #systemctl start glustereventsd
-```
+
+        # systemctl start glustereventsd
 
 8. Invoke self-heal on all the gluster volumes by running,
-```sh
-    #for i in `gluster volume list`; do gluster volume heal $i; done
-```
+
+        # for i in `gluster volume list`; do gluster volume heal $i; done
 
 9. Verify that there are no heal backlog by running the command for all the volumes,
-```sh
-    #gluster volume heal <volname> info
-```
-> **NOTE:** Before proceeding to upgrade the next server in the pool it is recommended to check the heal backlog. If there is a heal backlog, it is recommended to wait until the backlog is empty, or, the backlog does not contain any entries requiring a sync to the just upgraded server.
+
+        # gluster volume heal <volname> info
+
+    > **NOTE:** Before proceeding to upgrade the next server in the pool it is recommended to check the heal backlog. If there is a heal backlog, it is recommended to wait until the backlog is empty, or, the backlog does not contain any entries requiring a sync to the just upgraded server.
 
 10. Restart any gfapi based application stopped previously in step (2)
 
@@ -67,34 +61,30 @@ This procedure involves cluster downtime and during the upgrade window, clients 
 #### Steps to perform an offline upgrade:
 1. On every server in the trusted storage pool, stop all gluster services, either using the command below, or through other means,
 
-```sh
-    #killall glusterfs glusterfsd glusterd glustereventsd
-    #systemctl stop glustereventsd
-```
+        # killall glusterfs glusterfsd glusterd glustereventsd
+        # systemctl stop glustereventsd
+
 2. Stop all applications that access the volumes via gfapi (qemu, NFS-Ganesha, Samba, etc.), across all servers
 
 3. Install Gluster 3.12, on all servers
 
 4. Ensure that version reflects 3.12.x in the output of the following command on all servers,
-```sh
-    #gluster --version
-```
+
+        # gluster --version
 
 > **NOTE:** x is the minor release number for the release
 
 5. Start glusterd on all the upgraded servers
-```sh
-    #glusterd
-```
+
+        # glusterd
+
 6. Ensure that all gluster processes are online by checking the output of,
-```sh
-    #gluster volume status
-```
+
+        # gluster volume status
 
 7. If the glustereventsd service was previously enabled, it is required to start it using the commands below, or, through other means,
-```sh
-    #systemctl start glustereventsd
-```
+
+        # systemctl start glustereventsd
 
 8. Restart any gfapi based application stopped previously in step (2)
 

--- a/docs/Upgrade-Guide/upgrade_to_3.13.md
+++ b/docs/Upgrade-Guide/upgrade_to_3.13.md
@@ -17,41 +17,36 @@ This procedure involves upgrading **one server at a time**, while keeping the vo
 
 #### Repeat the following steps, on each server in the trusted storage pool, to upgrade the entire pool to 3.13 version:
 1. Stop all gluster services, either using the command below, or through other means,
-```sh
-    #killall glusterfs glusterfsd glusterd
-```
+
+        # killall glusterfs glusterfsd glusterd
 
 2. Stop all applications that run on this server and access the volumes via gfapi (qemu, NFS-Ganesha, Samba, etc.)
 
 3. Install Gluster 3.13
 
 4. Ensure that version reflects 3.13.x in the output of,
-```sh
-    #gluster --version
-```
+    
+        # gluster --version
 
 **NOTE:** x is the minor release number for the release
 
 5. Start glusterd on the upgraded server
-```sh
-    #glusterd
-```
+
+        # glusterd
 
 6. Ensure that all gluster processes are online by checking the output of,
-```sh
-    #gluster volume status
-```
+
+        # gluster volume status
 
 7. Self-heal all gluster volumes by running
-```sh
-    #for i in `gluster volume list`; do gluster volume heal $i; done
-```
+
+        # for i in `gluster volume list`; do gluster volume heal $i; done
 
 8. Ensure that there is no heal backlog by running the below command for all volumes
-```sh
-    #gluster volume heal <volname> info
-```
-> NOTE: If there is a heal backlog, wait till the backlog is empty, or the backlog does not have any entries needing a sync to the just upgraded server, before proceeding to upgrade the next server in the pool
+
+        # gluster volume heal <volname> info
+
+    > NOTE: If there is a heal backlog, wait till the backlog is empty, or the backlog does not have any entries needing a sync to the just upgraded server, before proceeding to upgrade the next server in the pool
 
 9. Restart any gfapi based application stopped previously in step (2)
 
@@ -61,28 +56,25 @@ This procedure involves cluster downtime and during the upgrade window, clients 
 #### Steps to perform an offline upgrade:
 1. On every server in the trusted storage pool, stop all gluster services, either using the command below, or through other means,
 
-```sh
-    #killall glusterfs glusterfsd glusterd
-```
+        # killall glusterfs glusterfsd glusterd
+
 2. Stop all applications that access the volumes via gfapi (qemu, NFS-Ganesha, Samba, etc.), across all servers
 
 3. Install Gluster 3.13, on all servers
 
 4. Ensure that version reflects 3.13.x in the output of the following command on all servers,
-```sh
-    #gluster --version
-```
+
+        # gluster --version
 
 **NOTE:** x is the minor release number for the release
 
 5. Start glusterd on all the upgraded servers
-```sh
-    #glusterd
-```
+
+        # glusterd
+
 6. Ensure that all gluster processes are online by checking the output of,
-```sh
-    #gluster volume status
-```
+
+        # gluster volume status
 
 7. Restart any gfapi based application stopped previously in step (2)
 

--- a/docs/Upgrade-Guide/upgrade_to_3.5.md
+++ b/docs/Upgrade-Guide/upgrade_to_3.5.md
@@ -21,12 +21,12 @@ If you have geo-replication session running, stop the session using the
 geo-rep stop command (please refer to step 1 of geo-rep upgrade steps
 provided below)
 
-1.  Execute "pre-upgrade-script-for-quota.sh" mentioned under "Upgrade Steps For Quota" section.
-2.  Stop all glusterd, glusterfsd and glusterfs processes on your server.
-3.  Install  GlusterFS 3.5.0
-4.  Start glusterd.
-5.  Ensure that all started volumes have processes online in “gluster volume status”.
-6.  Execute "Post-Upgrade Script" mentioned under "Upgrade Steps For Quota" section.
+1.  Execute "pre-upgrade-script-for-quota.sh" mentioned under "Upgrade Steps For Quota" section.
+2.  Stop all glusterd, glusterfsd and glusterfs processes on your server.
+3.  Install  GlusterFS 3.5.0
+4.  Start glusterd.
+5.  Ensure that all started volumes have processes online in “gluster volume status”.
+6.  Execute "Post-Upgrade Script" mentioned under "Upgrade Steps For Quota" section.
 
 You would need to repeat these steps on all servers that form your
 trusted storage pool.
@@ -49,13 +49,13 @@ NOTE: Rolling upgrade of geo-replication session from glusterfs version \< 3.5 t
 If you have quota configured, you need to perform step 1 and 7,
 otherwise you can skip it.
 
-1.  Execute "pre-upgrade-script-for-quota.sh" mentioned under "Upgrade Steps For Quota" section.
-2.  Stop all glusterd, glusterfs and glusterfsd processes on your server.
-3.  Install GlusterFS 3.5.0.
-4.  Start glusterd.
-5.  Run “gluster volume heal `<volname>` info” on all volumes and ensure that there is nothing left to be self-healed on every volume. If you have pending data for self-heal, run “gluster volume heal `<volname>`” and wait for self-heal to complete.
-6.  Ensure that all started volumes have processes online in “gluster volume status”.
-7.  Execute "Post-Upgrade Script" mentioned under "Upgrade Steps For Quota" section.
+1.  Execute "pre-upgrade-script-for-quota.sh" mentioned under "Upgrade Steps For Quota" section.
+2.  Stop all glusterd, glusterfs and glusterfsd processes on your server.
+3.  Install GlusterFS 3.5.0.
+4.  Start glusterd.
+5.  Run “gluster volume heal `<volname>` info” on all volumes and ensure that there is nothing left to be self-healed on every volume. If you have pending data for self-heal, run “gluster volume heal `<volname>`” and wait for self-heal to complete.
+6.  Ensure that all started volumes have processes online in “gluster volume status”.
+7.  Execute "Post-Upgrade Script" mentioned under "Upgrade Steps For Quota" section.
 
 Repeat the above steps on all servers that are part of your trusted
 storage pool.
@@ -166,7 +166,7 @@ passed as an argument in the command-line:
 
 -   Example:
 
-*For a volume "vol1" on which quota is enabled, invoke the script in the following way:*
+*For a volume "vol1" on which quota is enabled, invoke the script in the following way:*
 
         [root@server1 extras]#./post-upgrade-script-for-quota.sh vol1
 
@@ -214,20 +214,20 @@ covered in detail here.
 ​1. Stop the geo-replication session in older version ( \< 3.5) using
 the below command
 
-        #gluster volume geo-replication `<master_vol>` `<slave_host>`::`<slave_vol>` stop
+        #gluster volume geo-replication `<master_vol>` `<slave_host>`::`<slave_vol>` stop
 
 ​2. Now since the new geo-replication requires gfids of master and slave
 volume to be same, generate a file containing the gfids of all the files
 in master
 
-        cd /usr/share/glusterfs/scripts/ ;
-        bash generate-gfid-file.sh localhost:`<master_vol>` $PWD/get-gfid.sh    /tmp/master_gfid_file.txt ;
-        scp /tmp/master_gfid_file.txt root@`<slave_host>`:/tmp
+        cd /usr/share/glusterfs/scripts/ ;
+        bash generate-gfid-file.sh localhost:`<master_vol>` $PWD/get-gfid.sh    /tmp/master_gfid_file.txt ;
+        scp /tmp/master_gfid_file.txt root@`<slave_host>`:/tmp
 
 ​3. Now go to the slave host and aplly the gfid to the slave volume.
 
-        cd /usr/share/glusterfs/scripts/
-        bash slave-upgrade.sh localhost:`<slave_vol>` /tmp/master_gfid_file.txt    $PWD/gsync-sync-gfid
+        cd /usr/share/glusterfs/scripts/
+        bash slave-upgrade.sh localhost:`<slave_vol>` /tmp/master_gfid_file.txt    $PWD/gsync-sync-gfid
 
 This will ask you for password of all the nodes in slave cluster. Please
 provide them, if asked.
@@ -239,7 +239,7 @@ start)
 For instruction on creating new geo-rep seesion please refer
 distributed-geo-rep admin guide.
 
-        gluster volume geo-replication `<master_volume>` `<slave_host>`::`<slave_volume>` create push-pem force
-        gluster volume geo-replication `<master_volume>` `<slave_host>`::`<slave_volume>` start
+        gluster volume geo-replication `<master_volume>` `<slave_host>`::`<slave_volume>` create push-pem force
+        gluster volume geo-replication `<master_volume>` `<slave_host>`::`<slave_volume>` start
 
 ​6. Now your session is upgraded to use distributed-geo-rep

--- a/docs/Upgrade-Guide/upgrade_to_3.6.md
+++ b/docs/Upgrade-Guide/upgrade_to_3.6.md
@@ -8,14 +8,16 @@ GlusterFS clients. If you are not updating your clients to GlusterFS
 version 3.6 you need to disable client self healing process. You can
 perform this by below steps.
 
-        [root@~]# gluster v set testvol cluster.entry-self-heal off
-        volume set: success
-        [root@~]#
-        [root@~]# gluster v set testvol cluster.data-self-heal off
-        volume set: success
-        [root@~]# gluster v set testvol cluster.metadata-self-heal off
-        volume set: success
-        [root@~]#
+```console
+# gluster v set testvol cluster.entry-self-heal off
+volume set: success
+#
+# gluster v set testvol cluster.data-self-heal off
+volume set: success
+# gluster v set testvol cluster.metadata-self-heal off
+volume set: success
+#
+```
 
 ### GlusterFS upgrade from 3.5.x to 3.6.x
 
@@ -24,10 +26,10 @@ perform this by below steps.
 For this approach, schedule a downtime and prevent all your clients from
 accessing ( umount your volumes, stop gluster Volumes..etc)the servers.
 
-1.  Stop all glusterd, glusterfsd and glusterfs processes on your server.
-2.  Install  GlusterFS 3.6.0
-3.  Start glusterd.
-4.  Ensure that all started volumes have processes online in “gluster volume status”.
+1.  Stop all glusterd, glusterfsd and glusterfs processes on your server.
+2.  Install  GlusterFS 3.6.0
+3.  Start glusterd.
+4.  Ensure that all started volumes have processes online in “gluster volume status”.
 
 You would need to repeat these steps on all servers that form your
 trusted storage pool.
@@ -55,12 +57,12 @@ If you have geo-replication session running, stop the session using the
 geo-rep stop command (please refer to step 1 of geo-rep upgrade steps
 provided below)
 
-1.  Execute "pre-upgrade-script-for-quota.sh" mentioned under "Upgrade Steps For Quota" section.
-2.  Stop all glusterd, glusterfsd and glusterfs processes on your server.
-3.  Install  GlusterFS 3.6.0
-4.  Start glusterd.
-5.  Ensure that all started volumes have processes online in “gluster volume status”.
-6.  Execute "Post-Upgrade Script" mentioned under "Upgrade Steps For Quota" section.
+1.  Execute "pre-upgrade-script-for-quota.sh" mentioned under "Upgrade Steps For Quota" section.
+2.  Stop all glusterd, glusterfsd and glusterfs processes on your server.
+3.  Install  GlusterFS 3.6.0
+4.  Start glusterd.
+5.  Ensure that all started volumes have processes online in “gluster volume status”.
+6.  Execute "Post-Upgrade Script" mentioned under "Upgrade Steps For Quota" section.
 
 You would need to repeat these steps on all servers that form your
 trusted storage pool.
@@ -113,9 +115,11 @@ Invocation:
 Invoke the script by executing \`./pre-upgrade-script-for-quota.sh\`
 from the shell on any one of the nodes in the cluster.
 
--   Example:
+Example:
 
-        [root@server1 extras]#./pre-upgrade-script-for-quota.sh
+```console
+[root@server1 extras]#./pre-upgrade-script-for-quota.sh
+```
 
 *Post-Upgrade Script:*
 
@@ -172,11 +176,13 @@ In the first case, invoke post-upgrade-script-for-quota.sh from the
 shell for each volume with quota enabled, with the name of the volume
 passed as an argument in the command-line:
 
--   Example:
+Example:
 
-*For a volume "vol1" on which quota is enabled, invoke the script in the following way:*
+*For a volume "vol1" on which quota is enabled, invoke the script in the following way:*
 
-        [root@server1 extras]#./post-upgrade-script-for-quota.sh vol1
+```console
+[root@server1 extras]#./post-upgrade-script-for-quota.sh vol1
+```
 
 In the second case, the post-upgrade script picks on its own, the
 volumes on which quota is enabled, and executes the post-upgrade
@@ -184,9 +190,11 @@ procedure on each one of them. In this case, invoke
 post-upgrade-script-for-quota.sh from the shell with 'all' passed as an
 argument in the command-line:
 
--   Example:
+Example:
 
-        [root@server1 extras]#./post-upgrade-script-for-quota.sh all
+```console
+[root@server1 extras]#./post-upgrade-script-for-quota.sh all
+```
 
 Note:
 
@@ -222,20 +230,20 @@ covered in detail here.
 ​1.  Stop the geo-replication session in older version ( \< 3.5) using
 the below command
 
-        #gluster volume geo-replication `<master_vol>` `<slave_host>`::`<slave_vol>` stop
+        # gluster volume geo-replication `<master_vol>` `<slave_host>`::`<slave_vol>` stop
 
 ​2. Now since the new geo-replication requires gfids of master and slave
 volume to be same, generate a file containing the gfids of all the files
 in master
 
-        cd /usr/share/glusterfs/scripts/ ;
-        bash generate-gfid-file.sh localhost:`<master_vol>` $PWD/get-gfid.sh    /tmp/master_gfid_file.txt ;
-        scp /tmp/master_gfid_file.txt root@`<slave_host>`:/tmp
+        # cd /usr/share/glusterfs/scripts/ ;
+        # bash generate-gfid-file.sh localhost:`<master_vol>` $PWD/get-gfid.sh    /tmp/master_gfid_file.txt ;
+        # scp /tmp/master_gfid_file.txt root@`<slave_host>`:/tmp
 
 ​3. Now go to the slave host and aplly the gfid to the slave volume.
 
-        cd /usr/share/glusterfs/scripts/
-        bash slave-upgrade.sh localhost:`<slave_vol>` /tmp/master_gfid_file.txt    $PWD/gsync-sync-gfid
+        # cd /usr/share/glusterfs/scripts/
+        # bash slave-upgrade.sh localhost:`<slave_vol>` /tmp/master_gfid_file.txt    $PWD/gsync-sync-gfid
 
 This will ask you for password of all the nodes in slave cluster. Please
 provide them, if asked.
@@ -247,7 +255,7 @@ start)
 For instruction on creating new geo-rep seesion please refer
 distributed-geo-rep admin guide.
 
-        gluster volume geo-replication `<master_volume>` `<slave_host>`::`<slave_volume>` create push-pem force
-        gluster volume geo-replication `<master_volume>` `<slave_host>`::`<slave_volume>` start
+        # gluster volume geo-replication `<master_volume>` `<slave_host>`::`<slave_volume>` create push-pem force
+        # gluster volume geo-replication `<master_volume>` `<slave_host>`::`<slave_volume>` start
 
 ​6. Now your session is upgraded to use distributed-geo-rep

--- a/docs/Upgrade-Guide/upgrade_to_3.7.md
+++ b/docs/Upgrade-Guide/upgrade_to_3.7.md
@@ -13,14 +13,16 @@ version 3.6 along with your servers you would need to disable client
 self healing process before the upgrade. You can perform this by below
 steps.
 
-    [root@~]# gluster v set testvol cluster.entry-self-heal off
-    volume set: success
-    [root@~]#
-    [root@~]# gluster v set testvol cluster.data-self-heal off
-    volume set: success
-    [root@~]# gluster v set testvol cluster.metadata-self-heal off
-    volume set: success
-    [root@~]#
+```console
+# gluster v set testvol cluster.entry-self-heal off
+volume set: success
+#
+# gluster v set testvol cluster.data-self-heal off
+volume set: success
+# gluster v set testvol cluster.metadata-self-heal off
+volume set: success
+#
+```
 
 ### GlusterFS upgrade to 3.7.x
 
@@ -29,10 +31,10 @@ steps.
 For this approach, schedule a downtime and prevent all your clients from
 accessing (umount your volumes, stop gluster Volumes..etc) the servers.
 
-    1. Stop all glusterd, glusterfsd and glusterfs processes on your server.
-    2. Install  GlusterFS 3.7.0
-    3. Start glusterd.
-    4. Ensure that all started volumes have processes online in “gluster volume status”.
+    1. Stop all glusterd, glusterfsd and glusterfs processes on your server.
+    2. Install  GlusterFS 3.7.0
+    3. Start glusterd.
+    4. Ensure that all started volumes have processes online in “gluster volume status”.
 
 You would need to repeat these steps on all servers that form your
 trusted storage pool.
@@ -101,9 +103,11 @@ Invocation:
 Invoke the script by executing \`./pre-upgrade-script-for-quota.sh\`
 from the shell on any one of the nodes in the cluster.
 
--   Example:
+Example:
 
-        [root@server1 extras]#./pre-upgrade-script-for-quota.sh
+```console
+[root@server1 extras]#./pre-upgrade-script-for-quota.sh
+```
 
 *Post-Upgrade Script:*
 
@@ -160,11 +164,11 @@ In the first case, invoke post-upgrade-script-for-quota.sh from the
 shell for each volume with quota enabled, with the name of the volume
 passed as an argument in the command-line:
 
--   Example:
+Example: For a volume "vol1" on which quota is enabled, invoke the script in the following way:
 
-        For a volume "vol1" on which quota is enabled, invoke the script in the following way:
-      
-        [root@server1 extras]#./post-upgrade-script-for-quota.sh vol1
+```console
+[root@server1 extras]#./post-upgrade-script-for-quota.sh vol1
+```
 
 In the second case, the post-upgrade script picks on its own, the
 volumes on which quota is enabled, and executes the post-upgrade
@@ -172,9 +176,11 @@ procedure on each one of them. In this case, invoke
 post-upgrade-script-for-quota.sh from the shell with 'all' passed as an
 argument in the command-line:
 
--   Example:
+Example:
 
-        [root@server1 extras]#./post-upgrade-script-for-quota.sh all
+```console
+[root@server1 extras]#./post-upgrade-script-for-quota.sh all
+```
 
 Note:
 
@@ -198,22 +204,22 @@ ssh+gluster.
 ​1. Stop the geo-replication session in older version ( \< 3.5) using
 the below command
 
-        #gluster volume geo-replication <master_vol> <slave_host>::<slave_vol> stop
+        # gluster volume geo-replication <master_vol> <slave_host>::<slave_vol> stop
 
 ​2. Now since the new geo-replication requires gfids of master and slave
 volume to be same, generate a file containing the gfids of all the files
 in master
 
-        cd /usr/share/glusterfs/scripts/ ;
-        bash generate-gfid-file.sh localhost:<master_vol> $PWD/get-gfid.sh    /tmp/master_gfid_file.txt ;
-        scp /tmp/master_gfid_file.txt root@<slave_host>:/tmp
+        # cd /usr/share/glusterfs/scripts/ ;
+        # bash generate-gfid-file.sh localhost:<master_vol> $PWD/get-gfid.sh    /tmp/master_gfid_file.txt ;
+        # scp /tmp/master_gfid_file.txt root@<slave_host>:/tmp
 
 ​3. Upgrade the slave cluster installation to 3.7.0
 
 ​4. Now go to the slave host and apply the gfid to the slave volume.
 
-        cd /usr/share/glusterfs/scripts/
-        bash slave-upgrade.sh localhost:<slave_vol> /tmp/master_gfid_file.txt    $PWD/gsync-sync-gfid
+        # cd /usr/share/glusterfs/scripts/
+        # bash slave-upgrade.sh localhost:<slave_vol> /tmp/master_gfid_file.txt    $PWD/gsync-sync-gfid
 
 This will ask you for password of all the nodes in slave cluster. Please
 provide them, if asked. Also note that this will restart your slave
@@ -225,8 +231,8 @@ gluster volume (stop and start)
 For instruction on creating new geo-rep session please refer
 distributed-geo-rep chapter in admin guide.
 
-        gluster volume geo-replication <master_volume> <slave_host>::<slave_volume> create push-pem force
-        gluster volume geo-replication <master_volume> <slave_host>::<slave_volume> start
+        # gluster volume geo-replication <master_volume> <slave_host>::<slave_volume> create push-pem force
+        # gluster volume geo-replication <master_volume> <slave_host>::<slave_volume> start
 
 At this point, your distributed geo-replication should be configured
 appropriately.

--- a/docs/Upgrade-Guide/upgrade_to_3.8.md
+++ b/docs/Upgrade-Guide/upgrade_to_3.8.md
@@ -13,44 +13,38 @@
 The procedure involves upgrading one server at a time . On every storage server in your trusted storage pool:
 
 - Stop all gluster services using the below command or through your favorite way to stop them.
-```sh
+
         # killall glusterfs glusterfsd glusterd
-```
+
 - If you are using gfapi based applications (qemu, NFS-Ganesha, Samba etc.) on the servers, please stop those applications too.
 
 - Install Gluster 3.8
 
 - Ensure that version reflects 3.8.x in the output of
-```sh
+
         # gluster --version
-```
 
 - Start glusterd on the upgraded server
-```sh
+
         # glusterd
-```
 
 - Ensure that all gluster processes are online by executing
-```sh
+
         # gluster volume status
-```
 
 - Self-heal all gluster volumes by running
-```sh
+
         # for i in `gluster volume list`; do gluster volume heal $i; done
-```
 
 - Ensure that there is no heal backlog by running the below command for all volumes
-```sh
-       # gluster volume heal <volname> info
-```
+
+        # gluster volume heal <volname> info
+
 - Restart any gfapi based application stopped previously.
 
 - After the upgrade is complete on all servers, run the following command:
-```sh
-      # gluster volume set all cluster.op-version 30800
-```
 
+        # gluster volume set all cluster.op-version 30800
 
 ### Offline Upgrade Procedure 
 
@@ -58,33 +52,30 @@ For this procedure, schedule a downtime and prevent all your clients from access
 
 On every storage server in your trusted storage pool:
 - Stop all gluster services using the below command or through your favorite way to stop them.
-```sh
+
         # killall glusterfs glusterfsd glusterd
-```
+
 - If you are using gfapi based applications (qemu, NFS-Ganesha, Samba etc.) on the servers, please stop those applications too.
 
 - Install Gluster 3.8
 
 - Ensure that version reflects 3.8.x in the output of
-```sh
+
         # gluster --version
-```
 
 - Start glusterd on the upgraded server
-```sh
+
         # glusterd
-```
+
 - Ensure that all gluster processes are online by executing
-```sh
+
         # gluster volume status
-```
 
 - Restart any gfapi based application stopped previously.
 
 - After the upgrade is complete on all servers, run the following command:
-```sh
-      # gluster volume set all cluster.op-version 30800
-```
+
+        # gluster volume set all cluster.op-version 30800
 
 ### Upgrade Procedure for Clients
 

--- a/docs/Upgrade-Guide/upgrade_to_3.9.md
+++ b/docs/Upgrade-Guide/upgrade_to_3.9.md
@@ -6,7 +6,8 @@ guide](upgrade_to_3.8.md).
 
 Note that there is only a single difference, related to the `op-version`:
 
-- After the upgrade is complete on all servers, run the following command:
-```sh
-      #gluster volume set all cluster.op-version 30900
+After the upgrade is complete on all servers, run the following command:
+
+```console
+# gluster volume set all cluster.op-version 30900
 ```

--- a/docs/Upgrade-Guide/upgrade_to_4.0.md
+++ b/docs/Upgrade-Guide/upgrade_to_4.0.md
@@ -17,40 +17,35 @@ This procedure involves upgrading **one server at a time**, while keeping the vo
 
 #### Repeat the following steps, on each server in the trusted storage pool, to upgrade the entire pool to 4.0 version:
 1. Stop all gluster services, either using the command below, or through other means,
-```sh
-    #killall glusterfs glusterfsd glusterd
-```
+
+        # killall glusterfs glusterfsd glusterd
 
 2. Stop all applications that run on this server and access the volumes via gfapi (qemu, NFS-Ganesha, Samba, etc.)
 
 3. Install Gluster 4.0
 
 4. Ensure that version reflects 4.0.x in the output of,
-```sh
-    #gluster --version
-```
+
+        # gluster --version
 
 **NOTE:** x is the minor release number for the release
 
 5. Start glusterd on the upgraded server
-```sh
-    #glusterd
-```
+
+        # glusterd
 
 6. Ensure that all gluster processes are online by checking the output of,
-```sh
-    #gluster volume status
-```
+
+        # gluster volume status
 
 7. Self-heal all gluster volumes by running
-```sh
-    #for i in `gluster volume list`; do gluster volume heal $i; done
-```
+
+        # for i in `gluster volume list`; do gluster volume heal $i; done
 
 8. Ensure that there is no heal backlog by running the below command for all volumes
-```sh
-    #gluster volume heal <volname> info
-```
+
+        # gluster volume heal <volname> info
+
 > NOTE: If there is a heal backlog, wait till the backlog is empty, or the backlog does not have any entries needing a sync to the just upgraded server, before proceeding to upgrade the next server in the pool
 
 9. Restart any gfapi based application stopped previously in step (2)
@@ -61,28 +56,25 @@ This procedure involves cluster downtime and during the upgrade window, clients 
 #### Steps to perform an offline upgrade:
 1. On every server in the trusted storage pool, stop all gluster services, either using the command below, or through other means,
 
-```sh
-    #killall glusterfs glusterfsd glusterd
-```
+        # killall glusterfs glusterfsd glusterd
+
 2. Stop all applications that access the volumes via gfapi (qemu, NFS-Ganesha, Samba, etc.), across all servers
 
 3. Install Gluster 4.0, on all servers
 
 4. Ensure that version reflects 4.0.x in the output of the following command on all servers,
-```sh
-    #gluster --version
-```
+
+        # gluster --version
 
 **NOTE:** x is the minor release number for the release
 
 5. Start glusterd on all the upgraded servers
-```sh
-    #glusterd
-```
+
+        # glusterd
+
 6. Ensure that all gluster processes are online by checking the output of,
-```sh
-    #gluster volume status
-```
+
+        # gluster volume status
 
 7. Restart any gfapi based application stopped previously in step (2)
 

--- a/docs/Upgrade-Guide/upgrade_to_4.1.md
+++ b/docs/Upgrade-Guide/upgrade_to_4.1.md
@@ -17,46 +17,40 @@ This procedure involves upgrading **one server at a time**, while keeping the vo
 
 #### Repeat the following steps, on each server in the trusted storage pool, to upgrade the entire pool to 4.1 version:
 1. Stop all gluster services, either using the command below, or through other means,
-```sh
-    #killall glusterfs glusterfsd glusterd
-    #systemctl stop glustereventsd
-```
+
+        # killall glusterfs glusterfsd glusterd
+        # systemctl stop glustereventsd
 
 2. Stop all applications that run on this server and access the volumes via gfapi (qemu, NFS-Ganesha, Samba, etc.)
 
 3. Install Gluster 4.1
 
 4. Ensure that version reflects 4.1.x in the output of,
-```sh
-    #gluster --version
-```
+
+        # gluster --version
 
 > **NOTE:** x is the minor release number for the release
 
 5. Start glusterd on the upgraded server
-```sh
-    #glusterd
-```
+
+        # glusterd
 
 6. Ensure that all gluster processes are online by checking the output of,
-```sh
-    #gluster volume status
-```
+
+        # gluster volume status
 
 7. If the glustereventsd service was previously enabled, it is required to start it using the commands below, or, through other means,
-```sh
-    #systemctl start glustereventsd
-```
+
+        # systemctl start glustereventsd
 
 8. Invoke self-heal on all the gluster volumes by running,
-```sh
-    #for i in `gluster volume list`; do gluster volume heal $i; done
-```
+
+        # for i in `gluster volume list`; do gluster volume heal $i; done
 
 9. Verify that there are no heal backlog by running the command for all the volumes,
-```sh
-    #gluster volume heal <volname> info
-```
+
+        # gluster volume heal <volname> info
+
 > **NOTE:** Before proceeding to upgrade the next server in the pool it is recommended to check the heal backlog. If there is a heal backlog, it is recommended to wait until the backlog is empty, or, the backlog does not contain any entries requiring a sync to the just upgraded server.
 
 10. Restart any gfapi based application stopped previously in step (2)

--- a/docs/Upgrade-Guide/upgrade_to_5.md
+++ b/docs/Upgrade-Guide/upgrade_to_5.md
@@ -14,14 +14,17 @@ before an upgrade from releases older than release 4.1.0,
 - features.grace-timeout
 
 To check if these options are set use,
-```
+
+```console
 # gluster volume info
 ```
+
 and ensure that the above options are not part of the `Options Reconfigured:`
 section in the output of all volumes in the cluster.
 
 If these are set, then unset them using the following commands,
-```
+
+```console
 # gluster volume reset <volname> <option>
 ```
 

--- a/docs/Upgrade-Guide/upgrade_to_6.md
+++ b/docs/Upgrade-Guide/upgrade_to_6.md
@@ -17,14 +17,17 @@ before an upgrade from releases older than release 4.1.0,
 - features.grace-timeout
 
 To check if these options are set use,
-```
+
+```console
 # gluster volume info
 ```
+
 and ensure that the above options are not part of the `Options Reconfigured:`
 section in the output of all volumes in the cluster.
 
 If these are set, then unset them using the following commands,
-```
+
+```console
 # gluster volume reset <volname> <option>
 ```
 
@@ -61,7 +64,10 @@ Volumes using the existing Tier feature need to be converted to regular volumes
 before upgrading to this release.
 
 Command reference:
-    `volume tier <VOLNAME> detach <start|stop|status|commit|[force]>`
+
+```console
+volume tier <VOLNAME> detach <start|stop|status|commit|[force]>
+```
 
 ### Other miscellaneous features
 

--- a/docs/Upgrade-Guide/upgrade_to_7.md
+++ b/docs/Upgrade-Guide/upgrade_to_7.md
@@ -17,14 +17,17 @@ before an upgrade from releases older than release 4.1.0,
 - features.grace-timeout
 
 To check if these options are set use,
-```
+
+```console
 # gluster volume info
 ```
+
 and ensure that the above options are not part of the `Options Reconfigured:`
 section in the output of all volumes in the cluster.
 
 If these are set, then unset them using the following commands,
-```
+
+```console
 # gluster volume reset <volname> <option>
 ```
 
@@ -33,8 +36,6 @@ and the reset of these options to their defaults needs to be done **prior** to
 upgrading the cluster.
 
 ### Deprecated translators and upgrade procedure for volumes using these features
-
-
 
 [If you are upgrading from a release prior to release-6 be aware of deprecated xlators and functionality](https://docs.gluster.org/en/latest/Upgrade-Guide/upgrade_to_6/#deprecated-translators-and-upgrade-procedure-for-volumes-using-these-features). 
 

--- a/docs/presentations/index.md
+++ b/docs/presentations/index.md
@@ -2,10 +2,7 @@
 This is a collection of Gluster presentations from all over the world.
 We have a [slideshare account](http://www.slideshare.net/GlusterCommunity) where most of these presentations are stored.
 
-[FOSDEM 2017](https://fosdem.org/2017/) @ Brussels, Belgium
------------------------------------------------------------
-
-### February 5, 2017
+### [FOSDEM 2017](https://fosdem.org/2017/) @ Brussels, Belgium - February 5, 2017
 
 - [GlusterD-2.0: The next generation of GlusterFS management](https://fosdem.org/2017/schedule/event/glusterd2/) - Kaushal M
 - [Gluster Roadmap and Features](https://fosdem.org/2017/schedule/event/cephglustercommunity/) - Niels de Vos
@@ -13,127 +10,73 @@ We have a [slideshare account](http://www.slideshare.net/GlusterCommunity) where
 - [Hyper-converged, persistent storage for containers with GlusterFS](https://fosdem.org/2017/schedule/event/glustercontainer/) - Jose Rivera, Mohamed Ashiq Liyazudeen
 - [Kubernetes+GlusterFS Lightning Ver.](https://fosdem.org/2017/schedule/event/kubegluster/) - Jose Rivera, Mohamed Ashiq Liyazudeen
 
+### [PyCon India 2016](https://in.pycon.org/2016/) @ New Delhi, India - September 25, 2016
 
-[PyCon India 2016](https://in.pycon.org/2016/) @ New Delhi, India
-------------------------------------------------------------------
+- [Python bindings to GlusterFS - a distributed filesystem](https://speakerdeck.com/prashanthpai/python-bindings-to-glusterfs-a-distributed-filesystem) - Prashanth Pai
 
-### September 25, 2016
+### [Openshift Meetup  India](http://www.meetup.com/Opensource-PaaS-India-Meetup/) 2016 @Bangalore, India - June 11, 2016
 
--   [Python bindings to GlusterFS - a distributed filesystem](https://speakerdeck.com/prashanthpai/python-bindings-to-glusterfs-a-distributed-filesystem) - Prashanth Pai
+- [“GlusterFS and Openshift (slideshare)”](http://www.slideshare.net/HumbleChirammal/persistent-storage-in-openshift-using-glusterfs) -  Humble Devassy Chirammal, Mohamed Ashiq Liyazudeen
 
+### [GlusterFS Meetup Bangalore](http://www.meetup.com/glusterfs-India/events/229929410/) 2016 @ Bangalore, India - June 4, 2016
 
-[Openshift Meetup  India](http://www.meetup.com/Opensource-PaaS-India-Meetup/) 2016 @Bangalore, India
--------------------------------------------------------------------------------------------------------
-### June 11, 2016
+- [“GlusterFS Containers (slideshare)”](http://www.slideshare.net/AshiqAshiq/glusterfs-containers) - Humble Devassy Chirammal, Mohamed Ashiq Liyazudeen
+- ["gdeploy 2.0 (slideshare)"](http://www.slideshare.net/sac2279/gdeploy-20) - Sachidananda Urs, Nandaja Varma
 
--   [“GlusterFS and Openshift (slideshare)”](http://www.slideshare.net/HumbleChirammal/persistent-storage-in-openshift-using-glusterfs)-  Humble Devassy Chirammal, Mohamed Ashiq Liyazudeen
+### [OpenStack Days Istanbul ](http://openstackdaysistanbul.com/) 2016 @ Istanbul, Turkey - May 31, 2016
 
-[GlusterFS Meetup Bangalore](http://www.meetup.com/glusterfs-India/events/229929410/) 2016 @ Bangalore, India
--------------------------------------------------------------------------------------------------------------
+- [“Building Clouds That Scale-Out with GlusterFS”](https://goo.gl/QnHhr6) - Mustafa Resul CETINEL
 
-### June 4, 2016
-
--   [“GlusterFS Containers (slideshare)”](http://www.slideshare.net/AshiqAshiq/glusterfs-containers) -
-    Humble Devassy Chirammal, Mohamed Ashiq Liyazudeen
-
-- ["gdeploy 2.0 (slideshare)"](http://www.slideshare.net/sac2279/gdeploy-20) -
-  Sachidananda Urs, Nandaja Varma
-
-
-[OpenStack Days Istanbul ](http://openstackdaysistanbul.com/) 2016 @ Istanbul, Turkey
-------------------------------------------------------------------------------
-
-### May 31, 2016
-
--   [“Building Clouds That Scale-Out with GlusterFS”](https://goo.gl/QnHhr6)
-    Mustafa Resul CETINEL
-
-
-[NLUUG Voorjaarsconferentie](https://www.nluug.nl/activiteiten/events/vj16/programma.html) 2016 @ Bunnik, The Netherlands
----------------------------------------------------------------------------------------------------------
-
-### May 26, 2016
+### [NLUUG Voorjaarsconferentie](https://www.nluug.nl/activiteiten/events/vj16/programma.html) 2016 @ Bunnik, The Netherlands - May 26, 2016
 
 -   [Replication Techniques in Gluster](https://www.nluug.nl/activiteiten/events/vj16/abstracts/ab07.html)
     ([.odp](http://people.redhat.com/ndevos/talks/2016-05-NLUUG/20160526-replication-in-gluster.odp))
-    ([.pdf](http://people.redhat.com/ndevos/talks/2016-05-NLUUG/20160526-replication-in-gluster.pdf))
-    Niels de Vos
+    ([.pdf](http://people.redhat.com/ndevos/talks/2016-05-NLUUG/20160526-replication-in-gluster.pdf)) - Niels de Vos
 
-[Vault](https://www.linuxfoundation.org/tag/vault/) 2016 @ Raleigh, NC, US
-------------------------------------------------------------------------------
-
-### April 20-21, 2016
+### [Vault](https://www.linuxfoundation.org/tag/vault/) 2016 @ Raleigh, NC, US - Apr 20-21, 2016
 
 -   [GlusterD 2.0](https://vault2016.sched.org/event/68kl/glusterd-20-managing-distributed-file-system-using-a-centralized-store-atin-mukherjee-red-hat)
-    ([slideshare](http://www.slideshare.net/GlusterCommunity/gluster-d2-62086643))
-    Atin Mukherjee
+    ([slideshare](http://www.slideshare.net/GlusterCommunity/gluster-d2-62086643)) - Atin Mukherjee
 
-[Incontro DevOps Italia](http://www.incontrodevops.it/events/idi2016/) 2016 @ Bologna, Italy
---------------------------------------------------------------------------------------------
-
-### April 1, 2016
+### [Incontro DevOps Italia](http://www.incontrodevops.it/events/idi2016/) 2016 @ Bologna, Italy - Apr 1, 2016
 
 -   [Gluster roadmap, recent improvements and upcoming features](http://www.incontrodevops.it/sessions/gluster-roadmap-recent-improvements-and-upcoming-features/)
     [slideshare](http://www.slideshare.net/GlusterCommunity/20160401-glusterroadmap)
-    [Vimeo recording](https://vimeo.com/album/3949155/video/167706951)
-    Niels de Vos
+    [Vimeo recording](https://vimeo.com/album/3949155/video/167706951) - Niels de Vos
 
-[LinuxConfAU](https://linux.conf.au/) 2016 @ Geelong, Australia
----------------------------------------------------------------
-
-### February 03, 2016
+### [LinuxConfAU](https://linux.conf.au/) 2016 @ Geelong, Australia - Feb 03, 2016
 
 -   GlusterD thread synchronization using Userspace Read Copy Update (URCU)
-    [slideshare](http://www.slideshare.net/GlusterCommunity/gluster-d-threadsynchronizationusingurculca2016) -
-    Atin Mukherjee
+    [slideshare](http://www.slideshare.net/GlusterCommunity/gluster-d-threadsynchronizationusingurculca2016) - Atin Mukherjee
 
-[DevConf.CZ](http://devconf.cz/) 2016 @ Brno, Czech Republic
-------------------------------------------------------------
-
-### February 5, 2016
+### [DevConf.CZ](http://devconf.cz/) 2016 @ Brno, Czech Republic - February 5, 2016
 
 -    [Ceph, Gluster, Swift : Similarities and differences]
-     (https://speakerdeck.com/prashanthpai/ceph-gluster-swift-similarities-and-differences) -
-    Prashanth Pai, Thiago da Silva
+     (https://speakerdeck.com/prashanthpai/ceph-gluster-swift-similarities-and-differences) - Prashanth Pai, Thiago da Silva
 
-[FOSDEM](http://www.fosdem.org/2016) 2016 @ Brussels, Belgium
-------------------------------------------------------------------
-
-### January 30, 2016
+### [FOSDEM](http://www.fosdem.org/2016) 2016 @ Brussels, Belgium - January 30, 2016
 
 -   Gluster roadmap: Recent improvements and upcoming features
-    [slideshare](http://www.slideshare.net/GlusterCommunity/20160130-glusterroadmap)
-    Niels de Vos
+    [slideshare](http://www.slideshare.net/GlusterCommunity/20160130-glusterroadmap) - Niels de Vos
 
-[T-DOSE](http://www.t-dose.org/) 2015 @ Eindhoven, The Netherlands
-------------------------------------------------------------------
-
-### November 28, 2015
+### [T-DOSE](http://www.t-dose.org/) 2015 @ Eindhoven, The Netherlands - Nov 28, 2015
 
 -   Introduction into Scale-out Storage with Gluster
-    [slideshare](http://www.slideshare.net/GlusterCommunity/gluster-introtdose-62086654)
-    Niels de Vos
+    [slideshare](http://www.slideshare.net/GlusterCommunity/gluster-introtdose-62086654) - Niels de Vos
 
-Usenix LISA 2015 @ Washington DC, USA
--------------------------------------
-
-### Nov 8, 2015
+### Usenix LISA 2015 @ Washington DC, USA - Nov 8, 2015
 
 -   [GlusterFS Tutorial - Architecture](http://www.slideshare.net/GlusterCommunity/lisa-2015gluster-fsintroduction) -
     Rajesh Joseph & Poornima Gurusiddaiah
 -   [GlusterFS Tutorial - Hands-on](http://www.slideshare.net/GlusterCommunity/lisa-2015gluster-fshandson) -
     Rajesh Joseph & Poornima Gurusiddaiah
 
-Open Source Backup Conference @ Cologne, Germany
-------------------------------------------------
-
-### September 30, 2015
+### Open Source Backup Conference @ Cologne, Germany - September 30, 2015
 
 -   Scale-Out backups with Bareos and Gluster
     ([slideshare](http://www.slideshare.net/GlusterCommunity/scale-out-backupswithbareosandgluster-62086631)) - Niels de Vos
 
-2015 Storage Developer Conference
---------------------------------------
+### 2015 Storage Developer Conference
 
 -  Achieving Coherent and Aggressive Client Caching in Gluster, a Distributed System
 [pdf](http://www.snia.org/sites/default/files/SDC15_presentations/file_sys/Poornima_Sourmya_Achiving_Coherent_Aggressive_Client-2.pdf) - Poornima Gurusiddaiah, Soumya Koduri
@@ -142,130 +85,73 @@ Open Source Backup Conference @ Cologne, Germany
 [slideshare](http://www.slideshare.net/GlusterCommunity/introduction-to-highlyavailablenfsserveronscaleoutstoragesystemsbasedonglusterfssdc2015) - Soumya Koduri, Meghana Madhusudhan
 
 
-Gluster Summit 2015 @ Barcelona, Spain
---------------------------------------
+### Gluster Summit 2015 @ Barcelona, Spain
 
--   [Bug Triage in Gluster](http://www.slideshare.net/GlusterCommunity/bug-triage-ingluster) -
-    Niels de Vos
--   [Responsibilities of Gluster
-    Maintainers](http://www.slideshare.net/GlusterCommunity/responsibilities-of-glustermaintainers) -
-    Niels de Vos
--   [Leases and caching](http://www.slideshare.net/GlusterCommunity/leases-andcaching-final) -
-    Poornima Gurusiddaiah & Soumya Koduri
--   [Cache tiering in GlusterFS and future
-    directions](http://www.slideshare.net/GlusterCommunity/tiering-barcelona) - Dan Lambright
--   [Yet Another Deduplication
-    Library (YADL)](http://www.slideshare.net/GlusterCommunity/ydal-barcelona) - Dan Lambright
+- [Bug Triage in Gluster](http://www.slideshare.net/GlusterCommunity/bug-triage-ingluster) -
+  Niels de Vos
+- [Responsibilities of Gluster Maintainers](http://www.slideshare.net/GlusterCommunity/responsibilities-of-glustermaintainers) -
+  Niels de Vos
+- [Leases and caching](http://www.slideshare.net/GlusterCommunity/leases-andcaching-final) -
+  Poornima Gurusiddaiah & Soumya Koduri
+- [Cache tiering in GlusterFS and future directions](http://www.slideshare.net/GlusterCommunity/tiering-barcelona) - Dan Lambright
+- [Yet Another Deduplication Library (YADL)](http://www.slideshare.net/GlusterCommunity/ydal-barcelona) - Dan Lambright
 
-Gluster Conference @ NMAMIT, Nitte
-----------------------------------
+### Gluster Conference @ NMAMIT, Nitte - Apr 11, 2015
 
-### April 11, 2015
+- [Introduction to Open Source](http://www.slideshare.net/GlusterCommunity/introduction-to-open-source-62086626) - Niels de Vos, Red Hat
+- [Software Defined Storage](http://www.slideshare.net/GlusterCommunity/software-defined-storage-62086656) - Dan Lambright, Red Hat
+- [Introduction to GlusterFS](http://www.slideshare.net/GlusterCommunity/gluster-technical-overview) -  Kaleb S. KEITHLEY, Red Hat
+- [Data Deduplication](http://www.slideshare.net/GlusterCommunity/dedupe-nmamit) - Joseph Fernandes, Red Hat
+- [Quality of Service](http://www.slideshare.net/GlusterCommunity/qos-62086668) - Karthik US & Sukumar Poojary, 4th SEM, MCA, NMAMIT, Nitte
 
--   [Introduction to Open
-    Source](http://www.slideshare.net/GlusterCommunity/introduction-to-open-source-62086626) - Niels de Vos, Red Hat
+### Ceph & Gluster FS - Software Defined Storage Meetup - Jan 22, 2015
 
--   [Software Defined
-    Storage](http://www.slideshare.net/GlusterCommunity/software-defined-storage-62086656) - Dan
-    Lambright, Red Hat
+- [GlusterFS - Current Features & Roadmap](http://www.slideshare.net/GlusterCommunity/gluster-fs-currentfeaturesandroadmap-62089261) -
+  Niels de Vos, Red Hat
 
--   [Introduction to
-    GlusterFS](http://www.slideshare.net/GlusterCommunity/gluster-technical-overview) -  Kaleb S. KEITHLEY, Red Hat
+### Open source storage for bigdata :Fifth Elephant event - Jun 21, 2014
 
--   [Data Deduplication](http://www.slideshare.net/GlusterCommunity/dedupe-nmamit) - Joseph
-    Fernandes, Red Hat
--   [Quality of Service](http://www.slideshare.net/GlusterCommunity/qos-62086668) - Karthik US & Sukumar
-    Poojary, 4th SEM, MCA, NMAMIT, Nitte
+- [GlusterFS_Hadoop_fifth-elephant.odp](http://www.slideshare.net/GlusterCommunity/gluster-fs-hadoopfifthelephant) - Lalatendu Mohanty, Red Hat
 
-Ceph & Gluster FS - Software Defined Storage Meetup
-------------------------------------------------------------------------------------------------------------
+### Red Hat Summit 2014, San Francisco, California, USA - Apr 14-17, 2014
 
-### January 22, 2015
+- [Red Hat Storage Server Administration Deep Dive](http://people.redhat.com/dblack/summit2014/black_w_1650_Red_Hat_Storage_Server_administration_deep_dive.odp) -
+  [slideshare](http://www.slideshare.net/GlusterCommunity/dustin-black-red-hat-storage-server-administration-deep-dive) -
+  Dustin Black, Red Hat
+- [GlusterFS Stack Diagram](http://people.redhat.com/dblack/summit2014/gluster_stack.odp)
 
--   [GlusterFS - Current Features &
-    Roadmap](http://www.slideshare.net/GlusterCommunity/gluster-fs-currentfeaturesandroadmap-62089261) -
+### Gluster Community Night, Amsterdam, The Netherlands - Mar 4th, 2014
+
+- [GlusterFS for System Administrators](http://people.redhat.com/ndevos/talks/gluster_for_sysadmins-amsterdam-20140304.pdf) -
+  Niels de Vos, Red Hat
+
+### Gluster Community Day, London, United Kingdom - Oct 29th, 2013
+
+- [Developing Apps and Integrating with GlusterFS - Libgfapi.odp](http://www.slideshare.net/GlusterCommunity/developing-apps-andintegratingwithglusterfslibgfapi) -
+  Justin Clift, Red Hat
+
+### Gluster Community Day / LinuxCon Europ 2013, Edinburgh, United Kingdom - Oct 22-24, 2013
+
+- [GlusterFS Architecture & Roadmap](http://www.slideshare.net/GlusterCommunity/glusterfs-architectur-roadmap-linuxcon-eu-2013) - Vijay Bellur
+- [Integrating GlusterFS, qemu and oVirt](http://www.slideshare.net/GlusterCommunity/integrating-gluster-fsqemuandovirtvijaybellurlinuxconeu2013-62086638) - Vijay Bellur
+
+### Gluster Community Day, Stockholm, Sweden - Sep 4th, 2013
+
+-   [Gluster related development](http://people.redhat.com/ndevos/talks/Gluster-Stockholm-20130902.pdf) -
     Niels de Vos, Red Hat
 
-Open source storage for bigdata :Fifth Elephant event
------------------------------------------------------
-
-### June 21, 2014
-
--   [GlusterFS_Hadoop_fifth-elephant.odp](http://www.slideshare.net/GlusterCommunity/gluster-fs-hadoopfifthelephant) - Lalatendu Mohanty, Red
-    Hat
-
-Red Hat Summit 2014, San Francisco, California, USA
----------------------------------------------------
-
-### April 14-17, 2014
-
--   [Red Hat Storage Server Administration Deep
-    Dive](http://people.redhat.com/dblack/summit2014/black_w_1650_Red_Hat_Storage_Server_administration_deep_dive.odp) -
-    [slideshare](http://www.slideshare.net/GlusterCommunity/dustin-black-red-hat-storage-server-administration-deep-dive)
-    Dustin Black, Red Hat
-    -   [GlusterFS Stack
-        Diagram](http://people.redhat.com/dblack/summit2014/gluster_stack.odp)
-
-Gluster Community Night, Amsterdam, The Netherlands
----------------------------------------------------
-
-### March 4th, 2014
-
--   [GlusterFS for System
-    Administrators](http://people.redhat.com/ndevos/talks/gluster_for_sysadmins-amsterdam-20140304.pdf) -
-    Niels de Vos, Red Hat
-
-Gluster Community Day, London, United Kingdom
----------------------------------------------
-
-### October 29th, 2013
-
--   [Developing_Apps_and_Integrating_with_GlusterFS_-_Libgfapi.odp](http://www.slideshare.net/GlusterCommunity/developing-apps-andintegratingwithglusterfslibgfapi) -
-    Justin Clift, Red Hat
-
-Gluster Community Day / LinuxCon Europ 2013, Edinburgh, United Kingdom
-----------------------------------------------------------------------
-
-### October 22nd, 2013
-
--   GlusterFS - Architecture & Roadmap - Vijay Bellur
-    -   [GlusterFS_Architecture_&_Roadmap-Vijay_Bellur-LinuxCon_EU_2013](http://www.slideshare.net/GlusterCommunity/glusterfs-architectur-roadmap-linuxcon-eu-2013)
-
-### October 24th, 2013
-
--   Integrating GlusterFS, qemu and oVirt - Vijay Bellur
-    -   [Integrating_GlusterFS,_qemu_and_oVirt-Vijay_Bellur-LinuxCon_EU_2013](http://www.slideshare.net/GlusterCommunity/integrating-gluster-fsqemuandovirtvijaybellurlinuxconeu2013-62086638)
-
-Gluster Community Day, Stockholm, Sweden
-----------------------------------------
-
-### September 4th, 2013
-
--   [Gluster related
-    development](http://people.redhat.com/ndevos/talks/Gluster-Stockholm-20130902.pdf) -
-    Niels de Vos, Red Hat
-
-LOADays, Belgium
-----------------
-
-### April 6th, 2013
+### LOADays, Belgium - April 6th, 2013
 
 -   [Glusterfs_for_sysadmins-justin_clift](http://www.slideshare.net/GlusterCommunity/glusterfs-for-sysadminsjustinclift) - GlusterFS for
     SysAdmins, Justin Clift. For LOADays 2013 conference.
 
-CIALUG Des Moines, IA
----------------------
-
-### March 21st, 2013
+### CIALUG Des Moines, IA - March 21st, 2013
 
 -   Converged infrastruture with oVirt, KVM, and
     Gluster -
     Theron Conrey, Red Hat
 
-Gluster Community Summit, Bangalore
------------------------------------
-
-### March 7 & 8, 2013
+### Gluster Community Summit, Bangalore - March 7 & 8, 2013
 
 -   [SMB-GlusterDevMar2013](http://www.slideshare.net/GlusterCommunity/smb-gluster-devmar2013) - Chris Hertel, Red Hat
     -   [Video recording](https://www.youtube.com/watch?v=2RHemtFzIUM)
@@ -277,21 +163,13 @@ Gluster Community Summit, Bangalore
     [slideshare](http://www.slideshare.net/GlusterCommunity/gsummit-apis2013)
     (Jeff Darcy, Red Hat)
 
-Gluster Community Workshop at CERN in Geneva
---------------------------------------------
+### Gluster Community Workshop at CERN in Geneva - February 26, 2013
 
-### February 26, 2013
-
--   [Debugging GlusterFS with
-    Wireshark](http://www.slideshare.net/GlusterCommunity/debugging-withwiresharknielsdevos)
-    ([additional
-    files](http://people.redhat.com/ndevos/talks/debugging-glusterfs-with-wireshark.d/)),
+-   [Debugging GlusterFS with Wireshark](http://www.slideshare.net/GlusterCommunity/debugging-withwiresharknielsdevos)
+    ([additional files](http://people.redhat.com/ndevos/talks/debugging-glusterfs-with-wireshark.d/)),
     Niels de Vos
 
-Gluster Community Workshop at LinuxCon Europe
----------------------------------------------
-
-### November 8, 2012
+### Gluster Community Workshop at LinuxCon Europe - November 8, 2012
 
 -   [Gluster for Sysadmins](http://www.slideshare.net/GlusterCommunity/gluster-for-sysadmins) - Dustin Black, Red Hat
 -   [On-demand\_File\_Caching\_-\_Gustavo\_Brand](http://www.slideshare.net/GlusterCommunity/on-demand-filecachinggustavobrand) -
@@ -307,20 +185,13 @@ Gluster Community Workshop at LinuxCon Europe
 -   [QEMU_GlusterFS](http://www.slideshare.net/GlusterCommunity/qemu-gluster-fs) - QEMU integration
     with GlusterFS, Bharata Rao, IBM Linux Technology Center
 
-Software Developers' Conference (SNIA)
---------------------------------------
-
-### September 17, 2012
+### Software Developers' Conference (SNIA) - Sep 17, 2012
 
 -   Challenges and Futures
     [slideshare](http://www.slideshare.net/GlusterCommunity/sdc-challenges2012)
     (Jeff Darcy, Red Hat)
 
-
-Gluster Workshop at LinuxCon North America
-------------------------------------------
-
-### August 28, 2012
+### Gluster Workshop at LinuxCon North America - Aug 28, 2012
 
 -   Translator tutorial
     [slideshare](http://www.slideshare.net/GlusterCommunity/lcna-tutorial2012)


### PR DESCRIPTION
- Fixes to Markdown syntax for code highlight
- `console` is used to highlight shell sessions
- Uniform char used for shell "#" in code blocks.
- Snapshot page styles fixed
- Replica 2 examples changed to Replica 3

Signed-off-by: Aravinda VK <avishwan@redhat.com>