### PR TITLE
Adding space in front of commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Please create a fresh fork or clone if you have an older local clone.**
 If you are on EPEL 7 or Fedora, the first thing you will need is to install
 mkdocs, with the following command :
 
-    #sudo yum install mkdocs
+    # sudo yum install mkdocs
     
 For Fedora 23+ (run the following in root)
 
-    #dnf install python-pip
-    #pip install mkdocs
+    # dnf install python-pip
+    # pip install mkdocs
 
 Then you need to run mkdocs from the root of that repository:
 


### PR DESCRIPTION
Adding space in front of the commands to make them consistent throughout the README.md file in the root directory of the project.