### PR TITLE
Remove note on thin arbiter volumes only supported in GD2

### DIFF
--- a/docs/Administrator Guide/Thin-Arbiter-Volumes.md
+++ b/docs/Administrator Guide/Thin-Arbiter-Volumes.md
@@ -1,5 +1,4 @@
 # Thin Arbiter volumes in gluster
-(Currently supported only by GlusterD2)
 
 Thin Arbiter is a new type of quorum node where granularity of what is
 good and what is bad data is less compared to the traditional arbiter brick.


### PR DESCRIPTION
Since this is now in GD1, this should probably be removed? https://github.com/gluster/glusterfs/issues/687