### PR TITLE
Change gluster-server version in install docs

### DIFF
--- a/docs/Install-Guide/Install.md
+++ b/docs/Install-Guide/Install.md
@@ -55,7 +55,7 @@ apt install software-properties-common
 Then add the community GlusterFS PPA:
 
 ```console
-add-apt-repository ppa:gluster/glusterfs-3.8
+add-apt-repository ppa:gluster/glusterfs-7
 apt update
 ```
 


### PR DESCRIPTION
When trying to add `apt` repository on Ubuntu 16.04.6 LTS it yields this error:
```
$ add-apt-repository ppa:gluster/glusterfs-3.8
Cannot add PPA: 'ppa:~gluster/ubuntu/glusterfs-3.8'.
The team named '~gluster' has no PPA named 'ubuntu/glusterfs-3.8'
Please choose from the following available PPAs:
 * 'glusterd2-4.1':  glusterd2-4.1
 * 'glusterd2-4.1-xenial':  glusterd2-4.1 (xenial)
 * 'glusterd2-5':  glusterd2-5
 * 'glusterd2-5-xenial':  glusterd2-5 (xenial)
 * 'glusterfs-3.10':  glusterfs-3.10
 * 'glusterfs-3.11':  glusterfs-3.11
 * 'glusterfs-3.12':  glusterfs 3.12
 * 'glusterfs-3.13':  glusterfs-3.13
 * 'glusterfs-4.0':  glusterfs-4.0
 * 'glusterfs-4.1':  glusterfs-4.1
 * 'glusterfs-5':  glusterfs-5
 * 'glusterfs-6':  glusterfs-6
 * 'glusterfs-7':  glusterfs-7
 * 'glusterfs-coreutils':  glusterfs-coreutils
 * 'libntirpc-1.5':  libntirpc-1.5
 * 'libntirpc-1.6':  libntirpc-1.6
 * 'libntirpc-1.7':  libntirpc-1.7
 * 'nfs-ganesha-2.5':  nfs-ganesha-2.5
 * 'nfs-ganesha-2.6':  nfs-ganesha-2.6
 * 'nfs-ganesha-2.7':  nfs-ganesha-2.7
 * 'storhaug':  storhaug
```

I think it's reasonable to update the docs and point to the newest version.