### PR TITLE
Update README.md to mention all needed dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ mkdocs, with the following command :
 For Fedora 30+ (run the following in root)
 
     # dnf install python-pip
-    # pip install mkdocs
+    # pip install -r requirements.txt
 
 Then you need to run mkdocs from the root of that repository:
 


### PR DESCRIPTION
The `mkdocs-material` theme needs to be installed before building the docs. This is listed in the `requirements.txt` file but not the `README.md` file.