### PR TITLE
add hook scripts link to mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
      - Quotas: Administrator Guide/Directory Quota.md
      - Snapshots: Administrator Guide/Managing Snapshots.md
      - Trash: Administrator Guide/Trash.md
+     - Hook Scripts: Administrator Guide/Hook-scripts.md
   - Monitoring Workload: Administrator Guide/Monitoring Workload.md
   - Object Storage: Administrator Guide/Object Storage.md
   - GlusterFS Cinder: Administrator Guide/GlusterFS Cinder.md


### PR DESCRIPTION
Forgot to add the link to the yml file for PR #597 because of which it
does not appear in the side bar, though the content is visible at
https://docs.gluster.org/en/latest/Administrator%20Guide/Hook-scripts/.

Fixing it now.

Signed-off-by: Ravishankar N <ravishankar@redhat.com>