### PR TITLE
Add Dockerfile and Makefile for easily building docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 site/
 env/
 .env
+/.buildlog

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:7
+
+# RUN yum install -y epel-release
+RUN yum install -y python3 python3-setuptools
+RUN pip3 install mkdocs mkdocs-material
+
+ENV LC_ALL=en_US.utf-8 LANG=en_US.utf-8
+
+ENTRYPOINT ["mkdocs", "build"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build: docker/build
+	@docker run --rm -ti --user $(shell id -u):$(shell id -g) -v $(PWD):/docs:ro -v $(PWD)/site:/docs/site:rw -w /docs $(shell grep "Successfully built" .buildlog | cut -d ' ' -f 3)
+
+docker/build:
+	@docker build . | tee .buildlog

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you are on EPEL 7 or Fedora, the first thing you will need is to install
 mkdocs, with the following command :
 
     # sudo yum install mkdocs
-    
+
 For Fedora 30+ (run the following in root)
 
     # dnf install python-pip
@@ -37,3 +37,18 @@ Then you need to run mkdocs
 
 The result will be in the `site/` subdirectory, in HTML.
 
+# Building the docs in Docker
+
+Included is a Makefile and a Dockerfile, which enables you to easily build the
+docs inside Docker without installing any dependencies on your system.
+
+Simply run the following command to compile the docs:
+
+```sh
+make
+```
+
+This Makefile recipe builds a Docker image containing the dependencies required
+and runs `mkdocs` inside the built image, taking care to run the container as
+the current `uid` and `gid` so that your user has ownership of the results in
+the `./site` directory.


### PR DESCRIPTION
I prefer using Docker during development, especially for things that I rarely
use outside of a given project. This PR adds a Dockerfile and a Makefile for
easily building the documentation in a Docker container.