### PR TITLE
Updated the release notes 9.0

### DIFF
--- a/docs/release-notes/9.0.md
+++ b/docs/release-notes/9.0.md
@@ -27,9 +27,8 @@ initial 3 months, it will receive maintenance updates every 2 months till EOL.
 
 Added support for:
 
-  - io uring in Gluster
-  - support running with up to 5000 volumes
-  
+  - io_uring in Gluster (io_uring support in kernel required)
+  - support running with up to 5000 volumes (Testing done on: 5k volumes on 3 nodes, brick_mux was enabled with default configuration)  
 
 
 ### Features


### PR DESCRIPTION
Added
* io_uring requires kernel support
* 5k volume was tested on 3 nodes with brick mux enabled

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>