### PR TITLE
Updated the release notes 9.0

### DIFF
--- a/docs/release-notes/9.0.md
+++ b/docs/release-notes/9.0.md
@@ -27,7 +27,7 @@ initial 3 months, it will receive maintenance updates every 2 months till EOL.
 
 Added support for:
 
-  - io_uring in Gluster (io_uring support in kernel required)
+  - io_uring in Gluster (io_uring support in kernel required along with the presence of liburing library and headers)
   - support running with up to 5000 volumes (Testing done on: 5k volumes on 3 nodes, brick_mux was enabled with default configuration)  
 
 


### PR DESCRIPTION
In order for the storage.linux-io_uring option to work, in addition to
having a linux kernel >=5.1, we must also have liburing installed.
Otherwise, the glusterfs bricks will fall back to using normal I/O.

Signed-off-by: Ravishankar N <ravishankar@redhat.com>