### PR TITLE
Updating events doc

### DIFF
--- a/docs/Administrator-Guide/Events-APIs.md
+++ b/docs/Administrator-Guide/Events-APIs.md
@@ -1,5 +1,10 @@
 # Events APIs
 
+NOTE : Due to Selinux changes, glusterfs-selinux would have to be installed
+for events feature to function properly. Also, the range of ports which can
+be used in a system wherein Selinux rules are enforced should lie within
+the ephemeral port range.
+
 *New in version 3.9*
 
 ## Set PYTHONPATH(Only in case of Source installation)
@@ -192,12 +197,13 @@ optional arguments:
 Example output:
 
 ```console
-+-----------+-------+
-| NAME      | VALUE |
-+-----------+-------+
-| log_level | INFO  |
-| port      | 24009 |
-+-----------+-------+
++--------------------+-------+
+| NAME               | VALUE |
++--------------------+-------+
+| log-level          | INFO  |
+| port               | 55555 |
+| disable-events-log | False |
++--------------------+-------+
 ```
 
 To change any configuration,
@@ -320,32 +326,32 @@ BRICK_REPLACE                  | volume               | Volume Name
 Event Type                     | Attribute            | Description
 ------------------------------ | -------------------- | -----------
 GEOREP_CREATE                  | force                | Force option used during session Create
-                               | secondary            | Secondary Details(Secondaryhost::SecondaryVolume)
+                               | slave                | Slave Details(Slavehost::SlaveVolume)
                                | no_verify            | No verify option is used or not
                                | push_pem             | Push pem option is used or Not
                                | ssh_port             | If SSH port is configured during Session Create
-                               | primary              | Primary Volume Name
+                               | master               | Master Volume Name
 GEOREP_START                   | force                | Force option used during session Start
-                               | Primary              | Primary Volume Name
-                               | secondary            | Secondary Details(Secondaryhost::SecondaryVolume)
+                               | master               | Master Volume Name
+                               | slave                | Slave Details(Slavehost::SlaveVolume)
 GEOREP_STOP                    | force                | Force option used during session Stop
-                               | primary              | Primary Volume Name
-                               | secondary            | Secondary Details(Secondaryhost::SecondaryVolume)
+                               | master               | Master Volume Name
+                               | slave                | Slave Details(Slavehost::SlaveVolume)
 GEOREP_PAUSE                   | force                | Force option used during session Pause
-                               | primary              | Primary Volume Name
-                               | secondary            | Secondary Details(Secondaryhost::SecondaryVolume)
+                               | master               | Master Volume Name
+                               | slave                | Slave Details(Slavehost::SlaveVolume)
 GEOREP_RESUME                  | force                | Force option used during session Resume
-                               | primary              | Primary Volume Name
-                               | secondary            | Secondary Details(Secondaryhost::SecondaryVolume)
+                               | master               | Master Volume Name
+                               | slave                | Slave Details(Slavehost::SlaveVolume)
 GEOREP_DELETE                  | force                | Force option used during session Delete
-                               | primary              | Primary Volume Name
-                               | secondary            | Secondary Details(Secondaryhost::SecondaryVolume)
-GEOREP_CONFIG_SET              | primary              | Primary Volume Name
-                               | secondary            | Secondary Details(Secondaryhost::SecondaryVolume)
+                               | master               | Master Volume Name
+                               | slave                | Slave Details(Slavehost::SlaveVolume)
+GEOREP_CONFIG_SET              | master               | Master Volume Name
+                               | slave                | Slave Details(Slavehost::SlaveVolume)
                                | option               | Name of Geo-rep config
                                | value                | Changed Value
-GEOREP_CONFIG_RESET            | primary              | Primary Volume Name
-                               | secondary            | Secondary Details(Secondaryhost::SecondaryVolume)
+GEOREP_CONFIG_RESET            | master               | Master Volume Name
+                               | slave                | Slave Details(Slavehost::SlaveVolume)
                                | option               | Name of Geo-rep config
 
 ### Bitrot Events
@@ -532,14 +538,14 @@ EC_MIN_BRICKS_NOT_UP           | subvol               | Subvolume
 EC_MIN_BRICKS_UP               | subvol               | Subvolume
 
 ### Georep Events
-Event Type                     | Attribute              | Description
------------------------------- | --------------------   | -----------
-GEOREP_FAULTY                  | primary_node           | Hostname or IP of Primary Volume
-                               | brick_path             | Brick Path
-                               | secondary_host         | Secondary Hostname or IP
-                               | primary_volume         | Primary Volume Name
-                               | current_secondary_host | Current Secondary Host to which Geo-rep worker was trying to connect to
-                               | secondary_volume       | Secondary Volume Name
+Event Type                     | Attribute            | Description
+------------------------------ | -------------------- | -----------
+GEOREP_FAULTY                  | master_node          | Hostname or IP of Master Volume
+                               | brick_path           | Brick Path
+                               | slave_host           | Slave Hostname or IP
+                               | master_volume        | Master Volume Name
+                               | current_slave_host   | Current Slave Host to which Geo-rep worker was trying to connect to
+                               | slave_volume         | Slave Volume Name
 
 ### Quota Events
 Event Type                     | Attribute            | Description

--- a/docs/Administrator-Guide/Events-APIs.md
+++ b/docs/Administrator-Guide/Events-APIs.md
@@ -1,11 +1,11 @@
 # Events APIs
 
+*New in version 3.9*
+
 NOTE : Due to Selinux changes, glusterfs-selinux would have to be installed
 for events feature to function properly. Also, the range of ports which can
 be used in a system wherein Selinux rules are enforced should lie within
 the ephemeral port range.
-
-*New in version 3.9*
 
 ## Set PYTHONPATH(Only in case of Source installation)
 If Gluster is installed using source install, `cliutils` will get


### PR DESCRIPTION
Following changes have been pushed,
1. A note adding change in the default port
and the port range to be used when selinux is in
enforced mode.

2. Console output for `events-api config-get` is
updated.

Fixes: #647
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>