### PR TITLE
Commit policy small modification

### DIFF
--- a/docs/Developer-guide/Development-Workflow.md
+++ b/docs/Developer-guide/Development-Workflow.md
@@ -190,7 +190,7 @@ the following format
 -   Description of the code changes
 -   Reason for doing it this way (compared to others)
 -   Description of test cases
--   A reference ID
+-   A reference ID (optional if you run `./rfc.sh` after the commit to **Submit for review**)
 
 ### Test cases
 


### PR DESCRIPTION
`./rfc.sh` already asks for ISSUE ID reference hence providing a reference ID explicitly might not be needed.

Change:
Before:
![Screenshot from 2021-02-12 10-46-00](https://user-images.githubusercontent.com/77244483/107732898-910e9d80-6d1f-11eb-9fed-f2540901fd21.png)

After:
![Screenshot from 2021-02-12 10-44-57](https://user-images.githubusercontent.com/77244483/107732846-6de3ee00-6d1f-11eb-8051-5999645a0e18.png)
Signed-off-by: aujjwal-redhat <aujjwal@redhat.com>