### PR TITLE
Adding limitation in glusterfind.

### DIFF
--- a/docs/GlusterFS-Tools/glusterfind.md
+++ b/docs/GlusterFS-Tools/glusterfind.md
@@ -181,3 +181,4 @@ Where `START_TIME` is in unix epoch format, `START_TIME` will be zero for full f
 1. Deleted files will not get listed, since we can't convert GFID to Path if file/dir is deleted.
 2. Only new name will get listed if Renamed.
 3. All hardlinks will get listed.
+4. All the nodes are to be up and running for the successful operation of glusterfind.


### PR DESCRIPTION
Currently the glusterfind operation
is disrupted if even one node is down
during the pre. This is due to the fact
that changelogs are required to be
captured from the specific bricks and then
aggregated.

Fixes: #677
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>