### PR TITLE
Extra back ticks removed

### DIFF
--- a/docs/Administrator-Guide/Monitoring-Workload.md
+++ b/docs/Administrator-Guide/Monitoring-Workload.md
@@ -114,13 +114,13 @@ information anymore.
 
 Stop profiling using the following command:
 
-    `# gluster volume profile  stop`
+    # gluster volume profile  stop
 
 For example, to stop profiling on test-volume:
 
-    `# gluster volume profile  stop`
+    # gluster volume profile  stop
 
-    `Profiling stopped on test-volume`
+    Profiling stopped on test-volume
 
 ## Running GlusterFS Volume TOP Command
 
@@ -527,7 +527,7 @@ needed.
 -   Display information about a specific volume using the following
     command:
 
-    `# gluster volume info ``VOLNAME`
+    `# gluster volume info VOLNAME`
 
     For example, to display information about test-volume:
 


### PR DESCRIPTION
In the [Monitoring-Workload](https://docs.gluster.org/en/latest/Administrator-Guide/Monitoring-Workload/) page there are extra back-ticks in commands at few places. Removed them to prevent confusion.

Snaps :

Previous:
![Screenshot from 2021-05-06 14-21-25](https://user-images.githubusercontent.com/77244483/117270779-3052b500-ae77-11eb-90e5-a83881f46c41.png)
![Screenshot from 2021-05-06 14-24-16](https://user-images.githubusercontent.com/77244483/117270807-36e12c80-ae77-11eb-9b88-bd7ea7a78537.png)

After Modifications:
![Screenshot from 2021-05-06 14-23-32](https://user-images.githubusercontent.com/77244483/117270849-3fd1fe00-ae77-11eb-8e32-aedb11c87970.png)
![Screenshot from 2021-05-06 14-23-59](https://user-images.githubusercontent.com/77244483/117270852-41032b00-ae77-11eb-8999-77061cfa55b7.png)


Signed-off-by aujjwal-redhat <aujjwal@redhat.com>