### PR TITLE
Docs: Fix typo for 'nufa' volume option

### DIFF
--- a/docs/Administrator-Guide/Managing-Volumes.md
+++ b/docs/Administrator-Guide/Managing-Volumes.md
@@ -703,7 +703,7 @@ NUFA should be enabled before creating any data in the volume.
 
 Use the following command to enable NUFA:
 
-`# gluster volume set <VOLNAME> cluster.nufa enable on`
+`# gluster volume set <VOLNAME> cluster.nufa enable`
 
 **Important**
 


### PR DESCRIPTION
Fix:
Remove the extra `on` value from the docs.

Fixes: #685

Signed-off-by: nik-redhat <nladha@redhat.com>