### PR TITLE
Add glusterfs-libs change to libglusterfs0 in relnotes

### DIFF
--- a/docs/release-notes/8.0.md
+++ b/docs/release-notes/8.0.md
@@ -42,6 +42,7 @@ initial 3 months, it will receive maintenance updates every 2 months till EOL.
 - To validate other memory allocation implementations instead of libc's malloc added an option to build with tcmalloc library
 - Integrated Thin-arbiter with GD1
 - Client Handling of Elastic Clusters
+- The RPM package `glusterfs-libs` is replaced by `libglusterfs0`
 
 ## Major issues
 

--- a/docs/release-notes/8.0.md
+++ b/docs/release-notes/8.0.md
@@ -42,7 +42,7 @@ initial 3 months, it will receive maintenance updates every 2 months till EOL.
 - To validate other memory allocation implementations instead of libc's malloc added an option to build with tcmalloc library
 - Integrated Thin-arbiter with GD1
 - Client Handling of Elastic Clusters
-- The RPM package `glusterfs-libs` is replaced by `libglusterfs0`
+- The package `glusterfs-libs` is replaced by `libgfchangelog0`, `libgfrpc0`, `libgfxdr0`, and `libglusterfs0`; and additional libraries in `libgfapi0`, `libglusterd0`
 
 ## Major issues
 


### PR DESCRIPTION
For https://github.com/gluster/glusterfs/issues/2231: mention in "Features" section that the `glusterfs-libs` RPM package is replaced with `libglusterfs0`.