### PR TITLE
Geo-Replication: update about ssh-port config

### DIFF
--- a/docs/Administrator-Guide/Geo-Replication.md
+++ b/docs/Administrator-Guide/Geo-Replication.md
@@ -185,9 +185,13 @@ For example,
     create push-pem
 ```
 
-If custom SSH port is configured in Secondary nodes then,
+If custom SSH port (example: 50022) is configured in Secondary nodes then
 
 ```console
+# gluster volume geo-replication gvol-primary  \
+    geoaccount@snode1.example.com::gvol-secondary \
+    config ssh_port 50022
+
 # gluster volume geo-replication gvol-primary  \
     geoaccount@snode1.example.com::gvol-secondary \
     create ssh-port 50022 push-pem


### PR DESCRIPTION
Problem:
When a custom ssh port is set at the secondary volume,
   gluster volume geo-replication gvol-primary
   geoaccount@snode1.example.com::gvol-secondary
   create ssh-port <custom port> push-pem
is used. However, create push-pem command cannot alter
the config options.

One have to manually alter the config option, using:
   gluster volume geo-replication gvol-primary
   geoaccount@snode1.example.com::gvol-secondary
   config ssh_port <custom_port>

Solution:
Added about the command:
   gluster volume geo-replication gvol-primary
   geoaccount@snode1.example.com::gvol-secondary config ssh_port
   <custom_port>

before the usage of:
   gluster volume geo-replication gvol-primary
   geoaccount@snode1.example.com::gvol-secondary
   create ssh-port <custom port> push-pem

Fixes: #2819
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>