### PR TITLE
Release date field in Release notes

### DIFF
--- a/docs/Upgrade-Guide/README.md
+++ b/docs/Upgrade-Guide/README.md
@@ -4,6 +4,7 @@ Upgrading GlusterFS
 
 If you are using GlusterFS version 6.x or above, you can upgrade it to the following:
 
+-   [Upgrading to 10](./upgrade-to-10.md)
 -   [Upgrading to 9](./upgrade-to-9.md)
 -   [Upgrading to 8](./upgrade-to-8.md)
 -   [Upgrading to 7](./upgrade-to-7.md)

--- a/docs/release-notes/10.0.md
+++ b/docs/release-notes/10.0.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 10.0
 
+**Release date:** 16-Nov-2021
+
 This is a major release that includes a range of features, code improvements and stability fixes as noted below.
 
 A selection of the key features and changes are documented in this page.

--- a/docs/release-notes/8.0.md
+++ b/docs/release-notes/8.0.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 8.0
 
+**Release date:** 09-July-2020
+
 This is a major release that includes a range of features, code improvements and stability fixes as noted below.
 
 A selection of the key features and changes are documented in this page.

--- a/docs/release-notes/8.1.md
+++ b/docs/release-notes/8.1.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 8.1
 
+**Release date:** 27-Aug-2020
+
 This is a Improvements and bugfix release. The release notes for [8.0](8.0.md)
 contains a listing of all the new features that were added
 and bugs fixed in the GlusterFS 8 stable release.

--- a/docs/release-notes/8.2.md
+++ b/docs/release-notes/8.2.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 8.2
 
+**Release date:** 23-Sept-2020
+
 This is a Improvements and bugfix release. The release notes for [8.0](8.0.md), [8.1](8.1.md)
 contain a listing of all the new features that were added
 and bugs fixed in the GlusterFS 8 stable release.

--- a/docs/release-notes/8.3.md
+++ b/docs/release-notes/8.3.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 8.3
 
+**Release date:** 23-Dec-2020
+
 This is a bugfix release. The release notes for [8.0](8.0.md), [8.1](8.1.md) and [8.2](8.2.md)
 contain a listing of all the new features that were added
 and bugs fixed in the GlusterFS 8 stable release.

--- a/docs/release-notes/8.4.md
+++ b/docs/release-notes/8.4.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 8.4
 
+**Release date:** 01-Mar-2021
+
 This is a bugfix release. The release notes for [8.0](8.0.md), [8.1](8.1.md), [8.2](8.2.md) and [8.3](8.3.md)
 contain a listing of all the new features that were added
 and bugs fixed in the GlusterFS 8 stable release.

--- a/docs/release-notes/8.5.md
+++ b/docs/release-notes/8.5.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 8.5
 
+**Release date:** 17-May-2021
+
 This is a bugfix release. The release notes for [8.0](8.0.md), [8.1](8.1.md), [8.2](8.2.md), [8.3](8.3.md) and [8.4](8.4.md) contain a listing of all the new features that were added and bugs fixed in the GlusterFS 8 stable release.
 
 **NOTE:** 

--- a/docs/release-notes/8.6.md
+++ b/docs/release-notes/8.6.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 8.6
 
+**Release date:** 30-Aug-2021
+
 This is a bugfix release. The release notes for [8.0](8.0.md), [8.1](8.1.md), [8.2](8.2.md), [8.3](8.3.md), [8.4](8.4.md) and [8.5](8.5.md) contain a listing of all the new features that were added and bugs fixed in the GlusterFS 8 stable release.
 
 **NOTE:**

--- a/docs/release-notes/9.0.md
+++ b/docs/release-notes/9.0.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 9.0
 
+**Release date:** 05-Feb-2021
+
 This is a major release that includes a range of features, code improvements and stability fixes as noted below.
 
 A selection of the key features and changes are documented in this page.

--- a/docs/release-notes/9.1.md
+++ b/docs/release-notes/9.1.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 9.1
 
+**Release date:** 05-Apr-2021
+
 This is a bugfix and improvement release. The release notes for [9.0](9.0.md)
 contain a listing of all the new features that were added
 and bugs fixed in the GlusterFS 9 stable release.

--- a/docs/release-notes/9.2.md
+++ b/docs/release-notes/9.2.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 9.2
 
+**Release date:** 17-May-2021
+
 This is a bugfix and improvement release. The release notes for [9.0](9.0.md), [9.1](9.1.md) contain a listing of all the new features that were added and bugs fixed in the GlusterFS 9 stable release.
 
 **NOTE:** 

--- a/docs/release-notes/9.3.md
+++ b/docs/release-notes/9.3.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 9.3
 
+**Release date:** 15-Jul-2021 
+
 This is a bugfix and improvement release. The release notes for [9.0](9.0.md), [9.1](9.1.md), [9.2](9.2.md) contain a listing of all the new features that were added and bugs fixed in the GlusterFS 9 stable release.
 
 **NOTE:**

--- a/docs/release-notes/9.4.md
+++ b/docs/release-notes/9.4.md
@@ -1,5 +1,7 @@
 # Release notes for Gluster 9.4
 
+**Release date:** 14-Oct-2021
+
 This is a bugfix and improvement release. The release notes for [9.0](9.0.md), [9.1](9.1.md), [9.2](9.2.md), [9.3](9.3.md) contain a listing of all the new features that were added and bugs fixed in the GlusterFS 9 stable release.
 
 **NOTE:**


### PR DESCRIPTION
Added missing release date field in release notes, for releases 8/9/10.
Signed off by: Saju <sajmoham@redhat.com>