### PR TITLE
[docs] Remove public google site verification link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -268,7 +268,6 @@ nav:
           - Statedump: Troubleshooting/statedump.md
           - gfid to path: Troubleshooting/gfid-to-path.md
   - Glossary: ./glossary.md
-  - Google Site Verification: ./google64817fdc11b2f6b6.html
 
 extra_javascript:
   - js/fix-docs.js


### PR DESCRIPTION
The UID listed on this page is supposed to be kept private. Also,
this change just hides the hyperlink from the NAV, google crawlers
are still able to verify the site for authenticity. The way SSGs work,
if a file exists let's say "siteurl/myfile.html" and the route
"myfile.html" is not defined then the file at that location will be served
instead. That's why siteurl/googleXXXXX.html can still be accessed when an
explicit URL is provided (that's what crawlers already have).

Signed-off-by: black-dragon74 <niryadav@redhat.com>