### PR TITLE
Hide 'Copy to clipboard' on non-code blocks and improvements to `Getting Started` section

### DIFF
--- a/docs/Administrator-Guide/GlusterFS-Introduction.md
+++ b/docs/Administrator-Guide/GlusterFS-Introduction.md
@@ -1,29 +1,23 @@
-What is Gluster ?
-=================
+# What is Gluster ?
 
 Gluster is a scalable, distributed file system that aggregates disk storage resources from multiple servers into a single global namespace.
 
 ### Advantages
 
-  * Scales to several petabytes
-  * Handles thousands of clients
-  * POSIX compatible
-  * Uses commodity hardware
-  * Can use any ondisk filesystem that supports extended attributes
-  * Accessible using industry standard protocols like NFS and SMB
-  * Provides replication, quotas, geo-replication, snapshots and bitrot detection
-  * Allows optimization for different workloads
-  * Open Source
-
+- Scales to several petabytes
+- Handles thousands of clients
+- POSIX compatible
+- Uses commodity hardware
+- Can use any ondisk filesystem that supports extended attributes
+- Accessible using industry standard protocols like NFS and SMB
+- Provides replication, quotas, geo-replication, snapshots and bitrot detection
+- Allows optimization for different workloads
+- Open Source
 
 ![640px-glusterfs_architecture](../images/640px-GlusterFS-Architecture.png)
 
-
-
 Enterprises can scale capacity, performance, and availability on demand, with no vendor lock-in, across on-premise, public cloud, and hybrid environments.
 Gluster is used in production at thousands of organisations spanning media, healthcare, government, education, web 2.0, and financial services.
-
-
 
 ### Commercial offerings and support
 

--- a/docs/Quick-Start-Guide/Architecture.md
+++ b/docs/Quick-Start-Guide/Architecture.md
@@ -17,10 +17,10 @@ Gluster file system supports different
 types of volumes based on the requirements. Some volumes are good for
 scaling storage size, some for improving performance and some for both.
 
-1.\*\* **Distributed Glusterfs Volume** **- This is the type of volume which is created by default if no volume type is specified.
+1.**Distributed Glusterfs Volume** - This is the type of volume which is created by default if no volume type is specified.
 Here, files are distributed across various bricks in the volume. So file1
 may be stored only in brick1 or brick2 but not on both. Hence there is
-**no data redundancy\*\*. The purpose for such a storage volume is to easily & cheaply
+**no data redundancy**. The purpose for such a storage volume is to easily & cheaply
 scale the volume size. However this also means that a brick failure will
 lead to complete loss of data and one must rely on the underlying
 hardware for data loss protection.
@@ -63,7 +63,7 @@ Brick3: server3:/exp3
 Brick4: server4:/exp4
 ```
 
-2.\*\* **Replicated Glusterfs Volume** \*\*- In this volume we overcome the
+2.**Replicated Glusterfs Volume** - In this volume we overcome the
 risk of data loss which is present in the distributed volume. Here exact copies of
 the data are maintained on all bricks. The number of replicas in the
 volume can be decided by client while creating the volume. So we need to
@@ -92,7 +92,7 @@ gluster volume create test-volume replica 3 transport tcp \
 volume create: test-volume: success: please start the volume to access data
 ```
 
-3.\*\* **Distributed Replicated Glusterfs Volume\*\*** - In this volume files
+3.**Distributed Replicated Glusterfs Volume** - In this volume files
 are distributed across replicated sets of bricks. The number of bricks
 must be a multiple of the replica count. Also the order in which we
 specify the bricks is important since adjacent bricks become replicas of each
@@ -123,7 +123,7 @@ gluster volume create test-volume replica 3 transport tcp server1:/exp1 server2:
 volume create: test-volume: success: please start the volume to access data
 ```
 
-4.\*\* **Dispersed Glusterfs Volume\*\*** - Dispersed volumes are based on
+4.**Dispersed Glusterfs Volume** - Dispersed volumes are based on
 erasure codes. It stripes the encoded data of files, with some redundancy added,
 across multiple bricks in the volume. You can use dispersed volumes to
 have a configurable level of reliability with minimum space waste.
@@ -148,7 +148,7 @@ gluster volume create test-volume disperse 3 redundancy 1 server1:/exp1 server2:
 volume create: test-volume: success: please start the volume to access data
 ```
 
-5.\*\* **Distributed Dispersed Glusterfs Volume\*\*** -
+5.**Distributed Dispersed Glusterfs Volume** -
 Distributed dispersed volumes are the equivalent to distributed replicated volumes, but using dispersed subvolumes
 instead of replicated ones. The number of bricks must be a multiple of the 1st subvol.
 The purpose for such a volume is to easily scale the volume size and distribute the load

--- a/docs/Quick-Start-Guide/Architecture.md
+++ b/docs/Quick-Start-Guide/Architecture.md
@@ -1,5 +1,5 @@
-Architecture
-============
+# Architecture
+
 ![architecture](../images/GlusterFS_Translator_Stack.png)
 
 A gluster volume is a collection of servers belonging to a Trusted Storage Pool.
@@ -17,10 +17,10 @@ Gluster file system supports different
 types of volumes based on the requirements. Some volumes are good for
 scaling storage size, some for improving performance and some for both.
 
-1.__ **Distributed Glusterfs Volume** __- This is the type of volume which is created by default if no volume type is specified.
+1.\*\* **Distributed Glusterfs Volume** **- This is the type of volume which is created by default if no volume type is specified.
 Here, files are distributed across various bricks in the volume. So file1
 may be stored only in brick1 or brick2 but not on both. Hence there is
-**no data redundancy**. The purpose for such a storage volume is to easily & cheaply
+**no data redundancy\*\*. The purpose for such a storage volume is to easily & cheaply
 scale the volume size. However this also means that a brick failure will
 lead to complete loss of data and one must rely on the underlying
 hardware for data loss protection.
@@ -37,14 +37,20 @@ gluster volume create NEW-VOLNAME [transport [tcp | rdma | tcp,rdma]] NEW-BRICK.
 using TCP.
 
 ```console
-# gluster volume create test-volume server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4
+gluster volume create test-volume server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4
+```
+
+```{ .console .no-copy }
 volume create: test-volume: success: please start the volume to access data
 ```
 
-To display the volume info
+To display the volume info:
 
 ```console
-# gluster volume info
+gluster volume info
+```
+
+```{ .console .no-copy }
 Volume Name: test-volume
 Type: Distribute
 Status: Created
@@ -57,7 +63,7 @@ Brick3: server3:/exp3
 Brick4: server4:/exp4
 ```
 
-2.__ **Replicated Glusterfs Volume** __- In this volume we overcome the
+2.\*\* **Replicated Glusterfs Volume** \*\*- In this volume we overcome the
 risk of data loss which is present in the distributed volume. Here exact copies of
 the data are maintained on all bricks. The number of replicas in the
 volume can be decided by client while creating the volume. So we need to
@@ -78,12 +84,15 @@ gluster volume create NEW-VOLNAME [replica COUNT] [transport [tcp |rdma | tcp,rd
 **For example**, to create a replicated volume with three storage servers:
 
 ```console
-# gluster volume create test-volume replica 3 transport tcp \
+gluster volume create test-volume replica 3 transport tcp \
       server1:/exp1 server2:/exp2 server3:/exp3
+```
+
+```{ .console .no-copy }
 volume create: test-volume: success: please start the volume to access data
 ```
 
-3.__ **Distributed Replicated Glusterfs Volume**__ - In this volume files
+3.\*\* **Distributed Replicated Glusterfs Volume\*\*** - In this volume files
 are distributed across replicated sets of bricks. The number of bricks
 must be a multiple of the replica count. Also the order in which we
 specify the bricks is important since adjacent bricks become replicas of each
@@ -107,10 +116,14 @@ gluster volume create NEW-VOLNAME [replica COUNT] [transport [tcp | rdma | tcp,r
 mirror:
 
 ```console
-# gluster volume create test-volume replica 3 transport tcp server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4 server5:/exp5 server6:/exp6
+gluster volume create test-volume replica 3 transport tcp server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4 server5:/exp5 server6:/exp6
+```
+
+```{ .console .no-copy }
 volume create: test-volume: success: please start the volume to access data
 ```
-4.__ **Dispersed Glusterfs Volume**__ - Dispersed volumes are based on
+
+4.\*\* **Dispersed Glusterfs Volume\*\*** - Dispersed volumes are based on
 erasure codes. It stripes the encoded data of files, with some redundancy added,
 across multiple bricks in the volume. You can use dispersed volumes to
 have a configurable level of reliability with minimum space waste.
@@ -122,17 +135,20 @@ without interrupting the operation of the volume.
 Create a dispersed volume:
 
 ```
-# gluster volume create test-volume [disperse [<COUNT>]] [disperse-data <COUNT>] [redundancy <COUNT>] [transport tcp | rdma | tcp,rdma] <NEW-BRICK>
+gluster volume create test-volume [disperse [<COUNT>]] [disperse-data <COUNT>] [redundancy <COUNT>] [transport tcp | rdma | tcp,rdma] <NEW-BRICK>
 ```
 
 **For example**, three node dispersed volume with level of redundancy 1, (2 + 1):
 
 ```console
-# gluster volume create test-volume disperse 3 redundancy 1 server1:/exp1 server2:/exp2 server3:/exp3
+gluster volume create test-volume disperse 3 redundancy 1 server1:/exp1 server2:/exp2 server3:/exp3
+```
+
+```{ .console .no-copy }
 volume create: test-volume: success: please start the volume to access data
 ```
 
-5.__ **Distributed Dispersed Glusterfs Volume**__ -
+5.\*\* **Distributed Dispersed Glusterfs Volume\*\*** -
 Distributed dispersed volumes are the equivalent to distributed replicated volumes, but using dispersed subvolumes
 instead of replicated ones. The number of bricks must be a multiple of the 1st subvol.
 The purpose for such a volume is to easily scale the volume size and distribute the load
@@ -142,42 +158,45 @@ across various bricks.
 Create a distributed dispersed volume:
 
 ```
-# gluster volume create [disperse [<COUNT>]] [disperse-data <COUNT>] [redundancy <COUNT>] [transport tcp | rdma | tcp,rdma] <NEW-BRICK>
+gluster volume create [disperse [<COUNT>]] [disperse-data <COUNT>] [redundancy <COUNT>] [transport tcp | rdma | tcp,rdma] <NEW-BRICK>
 ```
 
 **For example**, six node distributed dispersed volume with level of redundancy 1, 2 x (2 + 1) = 6:
 
 ```console
-# gluster volume create test-volume disperse 3 redundancy 1 server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4 server5:/exp5 server6:/exp6
+gluster volume create test-volume disperse 3 redundancy 1 server1:/exp1 server2:/exp2 server3:/exp3 server4:/exp4 server5:/exp5 server6:/exp6
+```
+
+```{ .console .no-copy }
 volume create: test-volume: success: please start the volume to access data
 ```
 
 > **Note**:
 
-> -  A dispersed volume can be created by specifying the number of bricks in a
-   disperse set, by specifying the number of redundancy bricks, or both.
+> - A dispersed volume can be created by specifying the number of bricks in a
+>   disperse set, by specifying the number of redundancy bricks, or both.
 
-> -  If *disperse* is not specified, or the `<COUNT>` is missing, the
-   entire volume will be treated as a single disperse set composed by all
-   bricks enumerated in the command line.
+> - If _disperse_ is not specified, or the `<COUNT>` is missing, the
+>   entire volume will be treated as a single disperse set composed by all
+>   bricks enumerated in the command line.
 
-> -  If *redundancy* is not specified, it is computed automatically to be the
-   optimal value. If this value does not exist, it's assumed to be '1' and a
-   warning message is shown:
+> - If _redundancy_ is not specified, it is computed automatically to be the
+>   optimal value. If this value does not exist, it's assumed to be '1' and a
+>   warning message is shown:
 
 >        # gluster volume create test-volume disperse 4 server{1..4}:/bricks/test-volume
-         There isn't an optimal redundancy value for this configuration. Do you want to create the volume with redundancy 1 ? (y/n)
 
-> -  In all cases where *redundancy* is automatically computed and it's not
-   equal to '1', a warning message is displayed:
+>        There isn't an optimal redundancy value for this configuration. Do you want to create the volume with redundancy 1 ? (y/n)
+
+> - In all cases where _redundancy_ is automatically computed and it's not equal to '1', a warning message is displayed:
 
 >        # gluster volume create test-volume disperse 6 server{1..6}:/bricks/test-volume
-         The optimal redundancy for this configuration is 2. Do you want to create the volume with this value ? (y/n)
 
-> -  *redundancy* must be greater than 0, and the total number of bricks must
-   be greater than 2 * _redundancy_. This means that a dispersed volume must
-   have a minimum of 3 bricks.
+>       The optimal redundancy for this configuration is 2. Do you want to create the volume with this value ? (y/n)
 
+> - _redundancy_ must be greater than 0, and the total number of bricks must
+>   be greater than 2 \* _redundancy_. This means that a dispersed volume must
+>   have a minimum of 3 bricks.
 
 ### **FUSE**
 
@@ -195,7 +214,7 @@ languages.
 
 ![fuse_structure](https://cloud.githubusercontent.com/assets/10970993/7412530/67a544ae-ef61-11e4-8979-97dad4031a81.png)
 
-*Structural diagram of FUSE.*
+_Structural diagram of FUSE._
 
 This shows a filesystem "hello world" that is compiled to create a
 binary "hello". It is executed with a filesystem mount point /tmp/fuse.
@@ -213,61 +232,61 @@ opening /dev/fuse. This file can be opened multiple times, and the
 obtained file descriptor is passed to the mount syscall, to match up the
 descriptor with the mounted filesystem.
 
--   [More about userspace
-    filesystems](http://www.linux-mag.com/id/7814/)
--   [FUSE reference](http://fuse.sourceforge.net/)
+- [More about userspace
+  filesystems](http://www.linux-mag.com/id/7814/)
+- [FUSE reference](http://fuse.sourceforge.net/)
 
 ### Translators
 
 **Translating “translators”**:
 
--   A translator converts requests from users into requests for storage.
+- A translator converts requests from users into requests for storage.
 
-    *One to one, one to many, one to zero (e.g. caching)
+  \*One to one, one to many, one to zero (e.g. caching)
 
 ![translator](https://cloud.githubusercontent.com/assets/10970993/7412595/fd46c492-ef61-11e4-8f49-61dbd15b9695.png)
 
--   A translator can modify requests on the way through :
+- A translator can modify requests on the way through :
 
-    *convert one request type to another ( during the request transfer amongst the translators)
-    *modify paths, flags, even data (e.g. encryption)
+  *convert one request type to another ( during the request transfer amongst the translators)
+  *modify paths, flags, even data (e.g. encryption)
 
--   Translators can intercept or block the requests. (e.g. access
-    control)
+- Translators can intercept or block the requests. (e.g. access
+  control)
 
--   Or spawn new requests (e.g. pre-fetch)
+- Or spawn new requests (e.g. pre-fetch)
 
 **How Do Translators Work?**
 
--   Shared Objects
--   Dynamically loaded according to 'volfile'
+- Shared Objects
+- Dynamically loaded according to 'volfile'
 
-    *dlopen/dlsync
-    *setup pointers to parents / children
-    *call init (constructor)
-    *call IO functions through fops.
+  *dlopen/dlsync
+  *setup pointers to parents / children
+  *call init (constructor)
+  *call IO functions through fops.
 
--   Conventions for validating/ passing options, etc.
--   The configuration of translators (since GlusterFS 3.1) is managed
-    through the gluster command line interface (cli), so you don't need
-    to know in what order to graph the translators together.
+- Conventions for validating/ passing options, etc.
+- The configuration of translators (since GlusterFS 3.1) is managed
+  through the gluster command line interface (cli), so you don't need
+  to know in what order to graph the translators together.
 
 #### Types of Translators
 
 List of known translators with their current status.
 
-  Translator Type  | Functional Purpose
-  :---------------:| --------------------------------------------------------------------------------------------------------------
-  Storage          |Lowest level translator, stores and accesses data from local file system.
-  Debug            |Provide interface and statistics for errors and debugging.
-  Cluster          |Handle distribution and replication of data as it relates to writing to and reading from bricks & nodes.
-  Encryption       |Extension translators for on-the-fly encryption/decryption of stored data.
-  Protocol         |Extension translators for client/server communication protocols.
-  Performance      |Tuning translators to adjust for workload and I/O profiles.
-  Bindings         |Add extensibility, e.g. The Python interface written by Jeff Darcy to extend API interaction with GlusterFS.
-  System           |System access translators, e.g. Interfacing with file system access control.
-  Scheduler        |I/O schedulers that determine how to distribute new write operations across clustered systems.
-  Features         |Add additional features such as Quotas, Filters, Locks, etc.
+| Translator Type | Functional Purpose                                                                                           |
+| :-------------: | ------------------------------------------------------------------------------------------------------------ |
+|     Storage     | Lowest level translator, stores and accesses data from local file system.                                    |
+|      Debug      | Provide interface and statistics for errors and debugging.                                                   |
+|     Cluster     | Handle distribution and replication of data as it relates to writing to and reading from bricks & nodes.     |
+|   Encryption    | Extension translators for on-the-fly encryption/decryption of stored data.                                   |
+|    Protocol     | Extension translators for client/server communication protocols.                                             |
+|   Performance   | Tuning translators to adjust for workload and I/O profiles.                                                  |
+|    Bindings     | Add extensibility, e.g. The Python interface written by Jeff Darcy to extend API interaction with GlusterFS. |
+|     System      | System access translators, e.g. Interfacing with file system access control.                                 |
+|    Scheduler    | I/O schedulers that determine how to distribute new write operations across clustered systems.               |
+|    Features     | Add additional features such as Quotas, Filters, Locks, etc.                                                 |
 
 The default / general hierarchy of translators in vol files :
 
@@ -286,32 +305,32 @@ to go through is **fuse translator** which falls under the category of
 
 1.  **Cluster Translators**:
 
-    * DHT(Distributed Hash Table)
-    * AFR(Automatic File Replication)
+    - DHT(Distributed Hash Table)
+    - AFR(Automatic File Replication)
 
 1.  **Performance Translators**:
 
-    * io-cache
-    * io-threads
-    * md-cache
-    * O-B (open behind)
-    * QR (quick read)
-    * r-a (read-ahead)
-    * w-b (write-behind)
+    - io-cache
+    - io-threads
+    - md-cache
+    - O-B (open behind)
+    - QR (quick read)
+    - r-a (read-ahead)
+    - w-b (write-behind)
 
 Other **Feature Translators** include:
 
-* changelog
-* locks - GlusterFS has locks  translator which provides the following internal locking operations
+- changelog
+- locks - GlusterFS has locks translator which provides the following internal locking operations
   called `inodelk`, `entrylk`,
   which are used by afr to achieve synchronization of operations on files or directories that conflict with each other.
-* marker
-* quota
+- marker
+- quota
 
 **Debug Translators**
 
-* trace - To trace the error logs generated during the communication amongst the translators.
-* io-stats
+- trace - To trace the error logs generated during the communication amongst the translators.
+- io-stats
 
 #### DHT(Distributed Hash Table) Translator
 
@@ -385,7 +404,7 @@ unlike AFR which is intra-cluster replication. This is mainly useful for
 backup of entire data for disaster recovery.
 
 Geo-replication uses a primary-secondary model, whereby replication occurs
-between a **Primary** and a **Secondary**, both of which should 
+between a **Primary** and a **Secondary**, both of which should
 be GlusterFS volumes.
 Geo-replication provides an incremental replication service over Local
 Area Networks (LANs), Wide Area Network (WANs), and across the
@@ -518,7 +537,7 @@ a client process will also be created. Now our filesystem is ready to
 use. We can mount this volume on a client machine very easily as follows
 and use it like we use a local storage:
 
- mount.glusterfs `<IP or hostname>`:`<volume_name>` `<mount_point>`
+mount.glusterfs `<IP or hostname>`:`<volume_name>` `<mount_point>`
 
 IP or hostname can be that of any node in the trusted server pool in
 which the required volume is created.
@@ -547,23 +566,23 @@ to each file operation or fop supported by glusterfs. The request will
 hit the corresponding function in each of the translators. Main client
 translators include:
 
--   FUSE translator
--   DHT translator- DHT translator maps the request to the correct brick
-    that contains the file or directory required.
--   AFR translator- It receives the request from the previous translator
-    and if the volume type is replicate, it duplicates the request and
-    passes it on to the Protocol client translators of the replicas.
--   Protocol Client translator- Protocol Client translator is the last
-    in the client translator stack. This translator is divided into
-    multiple threads, one for each brick in the volume. This will
-    directly communicate with the glusterfsd of each brick.
+- FUSE translator
+- DHT translator- DHT translator maps the request to the correct brick
+  that contains the file or directory required.
+- AFR translator- It receives the request from the previous translator
+  and if the volume type is replicate, it duplicates the request and
+  passes it on to the Protocol client translators of the replicas.
+- Protocol Client translator- Protocol Client translator is the last
+  in the client translator stack. This translator is divided into
+  multiple threads, one for each brick in the volume. This will
+  directly communicate with the glusterfsd of each brick.
 
 In the storage server node that contains the brick in need, the request
 again goes through a series of translators known as server translators,
 main ones being:
 
--   Protocol server translator
--   POSIX translator
+- Protocol server translator
+- POSIX translator
 
 The request will finally reach VFS and then will communicate with the
 underlying native filesystem. The response will retrace the same path.

--- a/docs/Quick-Start-Guide/Architecture.md
+++ b/docs/Quick-Start-Guide/Architecture.md
@@ -134,7 +134,7 @@ without interrupting the operation of the volume.
 ![Dispersed volume](../images/New-DispersedVol.png)
 Create a dispersed volume:
 
-```
+```console
 gluster volume create test-volume [disperse [<COUNT>]] [disperse-data <COUNT>] [redundancy <COUNT>] [transport tcp | rdma | tcp,rdma] <NEW-BRICK>
 ```
 
@@ -157,7 +157,7 @@ across various bricks.
 ![distributed_dispersed_volume](../images/New-Distributed-DisperseVol.png)
 Create a distributed dispersed volume:
 
-```
+```console
 gluster volume create [disperse [<COUNT>]] [disperse-data <COUNT>] [redundancy <COUNT>] [transport tcp | rdma | tcp,rdma] <NEW-BRICK>
 ```
 

--- a/docs/Quick-Start-Guide/Quickstart.md
+++ b/docs/Quick-Start-Guide/Quickstart.md
@@ -1,11 +1,10 @@
-Installing GlusterFS - a Quick Start Guide
--------
+## Installing GlusterFS - a Quick Start Guide
 
 #### Purpose of this document
 
 This document is intended to provide a step-by-step guide to setting up
 GlusterFS for the first time with minimum degree of complexity. For the purposes of this guide, it is
-required to use Fedora 30 (or, higher, see https://fedoraproject.org/wiki/End_of_life) virtual machine instances.
+required to use Fedora 30 (or, higher, see [https://fedoraproject.org/wiki/End_of_life](https://fedoraproject.org/wiki/End_of_life)) virtual machine instances.
 
 After you deploy GlusterFS by following these steps,
 we recommend that you read the GlusterFS Admin Guide to how to select a volume type that fits your
@@ -30,23 +29,21 @@ article](https://ttboj.wordpress.com/2014/01/08/automatically-deploying-glusterf
 
 ### Step 1 – Have at least three nodes
 
--   Fedora 30 (or later) on 3 nodes named "server1", "server2" and "server3"
--   A working network connection
--   At least two virtual disks, one for the OS installation, and one to be
-    used to serve GlusterFS storage (sdb), on each of these VMs. This will
-    emulate a real-world deployment, where you would want to separate
-    GlusterFS storage from the OS install.
--   Setup NTP on each of these servers to get the proper functioning of
-    many applications on top of filesystem. This is an important requirement
-
+- Fedora 30 (or later) on 3 nodes named "server1", "server2" and "server3"
+- A working network connection
+- At least two virtual disks, one for the OS installation, and one to be
+  used to serve GlusterFS storage (sdb), on each of these VMs. This will
+  emulate a real-world deployment, where you would want to separate
+  GlusterFS storage from the OS install.
+- Setup NTP on each of these servers to get the proper functioning of
+  many applications on top of filesystem. This is an important requirement
 
 **Note**: GlusterFS stores its dynamically generated configuration files
-    at `/var/lib/glusterd`. If at any point in time GlusterFS is unable to
-    write to these files (for example, when the backing filesystem is full),
-    it will at minimum cause erratic behavior for your system; or worse,
-    take your system offline completely. It is recommended to create separate
-    partitions for directories such as `/var/log` to reduce the chances of this happening.
-
+at `/var/lib/glusterd`. If at any point in time GlusterFS is unable to
+write to these files (for example, when the backing filesystem is full),
+it will at minimum cause erratic behavior for your system; or worse,
+take your system offline completely. It is recommended to create separate
+partitions for directories such as `/var/log` to reduce the chances of this happening.
 
 ### Step 2 - Format and mount the bricks
 
@@ -57,28 +54,37 @@ Perform this step on all the nodes, "server{1,2,3}"
 The following examples assume that the brick will be residing on /dev/sdb1.
 
 ```console
-# mkfs.xfs -i size=512 /dev/sdb1
-# mkdir -p /data/brick1
-# echo '/dev/sdb1 /data/brick1 xfs defaults 1 2' >> /etc/fstab
-# mount -a && mount
+mkfs.xfs -i size=512 /dev/sdb1
+mkdir -p /data/brick1
+echo '/dev/sdb1 /data/brick1 xfs defaults 1 2' >> /etc/fstab
+mount -a && mount
 ```
 
 You should now see sdb1 mounted at /data/brick1
-
 
 ### Step 3 - Installing GlusterFS
 
 Install the software
 
 ```console
-# yum install glusterfs-server
+yum install glusterfs-server
 ```
 
 Start the GlusterFS management daemon:
 
 ```console
-# service glusterd start
-# service glusterd status
+service glusterd start
+```
+
+Check the status of the daemon:
+
+```console
+service glusterd status
+```
+
+You should see something like this:
+
+```{ .console .no-copy }
 glusterd.service - LSB: glusterfs server
        Loaded: loaded (/etc/rc.d/init.d/glusterd)
    Active: active (running) since Mon, 13 Aug 2012 13:02:11 -0700; 2s ago
@@ -89,39 +95,37 @@ glusterd.service - LSB: glusterfs server
 	   └ 19309 /usr/sbin/glusterfs -f /var/lib/glusterd/nfs/nfs-server.vol -p /var/lib/glusterd/...
 ```
 
-        
 ### Step 4 - Configure the firewall
 
 The gluster processes on the nodes need to be able to communicate with each other.
 To simplify this setup, configure the firewall on each node to accept all traffic from the other node.
 
 ```console
-# iptables -I INPUT -p all -s <ip-address> -j ACCEPT
+iptables -I INPUT -p all -s <ip-address> -j ACCEPT
 ```
 
 where ip-address is the address of the other node.
-
 
 ### Step 5 - Configure the trusted pool
 
 From "server1"
 
 ```console
-# gluster peer probe server2
-# gluster peer probe server3
+gluster peer probe server2
+gluster peer probe server3
 ```
 
 Note: When using hostnames, the first server i.e, `server1` needs to be probed from
-***one*** other server to set its hostname. Reason being when the other server 
-i.e, `server2` is probed from `server1` it may happen that the hosts are 
+**_one_** other server to set its hostname. Reason being when the other server
+i.e, `server2` is probed from `server1` it may happen that the hosts are
 configured in a way that the IP Address of the server is transmitted on probing.
-So in order to use the hostnames in the cluster, it is advised to probe back the 
+So in order to use the hostnames in the cluster, it is advised to probe back the
 `server1` from `server2`, `server3` or upto nth server based on the cluster size.
 
 From "server2"
 
 ```console
-# gluster peer probe server1
+gluster peer probe server1
 ```
 
 Note: Once this pool has been established, only trusted members may
@@ -131,12 +135,12 @@ must be probed from the pool.
 Check the peer status on server1
 
 ```console
-# gluster peer status
+gluster peer status
 ```
 
 You should see something like this (the UUID will differ)
 
-```console
+```{ .console .no-copy }
 Number of Peers: 2
 
 Hostname: server2
@@ -153,27 +157,42 @@ State: Peer in Cluster (Connected)
 On all servers:
 
 ```console
-# mkdir -p /data/brick1/gv0
+mkdir -p /data/brick1/gv0
 ```
 
 From any single server:
 
 ```console
-# gluster volume create gv0 replica 3 server1:/data/brick1/gv0 server2:/data/brick1/gv0 server3:/data/brick1/gv0
+gluster volume create gv0 replica 3 server1:/data/brick1/gv0 server2:/data/brick1/gv0 server3:/data/brick1/gv0
+```
+
+On successful operation, you should see something like:
+
+```{ .console .no-copy }
 volume create: gv0: success: please start the volume to access data
-# gluster volume start gv0
+```
+
+Then start the newly created volume:
+
+```console
+gluster volume start gv0
+```
+
+You should see something like:
+
+```{ .console .no-copy }
 volume start: gv0: success
 ```
 
 Confirm that the volume shows "Started":
 
 ```console
-# gluster volume info
+gluster volume info
 ```
 
 You should see something like this (the Volume ID will differ):
 
-```console
+```{ .console .no-copy }
 Volume Name: gv0
 Type: Replicate
 Volume ID: f25cc3d8-631f-41bd-96e1-3e22a4c6f71f
@@ -194,7 +213,6 @@ Note: If the volume does not show "Started", the files under
 diagnose the situation. These logs can be looked at on one or, all the
 servers configured.
 
-
 ### Step 7 - Testing the GlusterFS volume
 
 For this step, we will use one of the servers to mount the volume.
@@ -204,24 +222,23 @@ be installed on the client machine, we will use one of the servers as
 a simple place to test first , as if it were that "client".
 
 ```console
-# mount -t glusterfs server1:/gv0 /mnt
-# for i in `seq -w 1 100`; do cp -rp /var/log/messages /mnt/copy-test-$i; done
+mount -t glusterfs server1:/gv0 /mnt
+for i in `seq -w 1 100`; do cp -rp /var/log/messages /mnt/copy-test-$i; done
 ```
 
 First, check the client mount point:
 
 ```console
-# ls -lA /mnt/copy* | wc -l
+ls -lA /mnt/copy* | wc -l
 ```
 
 You should see 100 files returned. Next, check the GlusterFS brick mount
 points on each server:
 
 ```console
-# ls -lA /data/brick1/gv0/copy*
+ls -lA /data/brick1/gv0/copy*
 ```
 
 You should see 100 files on each server using the method we listed here.
 Without replication, in a distribute only volume (not detailed here), you
 should see about 33 files on each one.
-

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1,0 +1,3 @@
+.no-copy .md-clipboard {
+  display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,9 @@ site_description: Project documentation for Gluster Filesystem
 repo_url: https://github.com/gluster/glusterdocs/
 docs_dir: docs
 
+markdown_extensions:
+  - attr_list
+
 theme:
   name: material
   favicon: images/favicon.ico
@@ -272,3 +275,6 @@ nav:
 
 extra_javascript:
   - js/fix-docs.js
+
+extra_css:
+  - css/custom.css


### PR DESCRIPTION
[QOL] Hide 'Copy To Clipboard' button on non-code blocks
Site wide there are multiple code blocks that do not contain
any code in them. But still a `Copy code to clipboard` button
is shown, this patch addresses this issue. It is a QOL improvement
that makes distinguishing code blocks visually and functionally easier.

To use this new feature, we need to start our code block like:
```text
```{ .language_name .no-copy }
```

Where `language_name` is something that can vary (`console` in our case mostly).
The `.no-copy` attribute is what disables the function on that particular block.


This is a first of many patches that'll follow for subsequent sections site-wide
which moves OLD `md` syntax to NEW one and also address any other semantics that come
into notice.

Regards