### PR TITLE
[nav-qol] Add support for anchor tracking in the nav bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ markdown_extensions:
 theme:
   name: material
   favicon: images/favicon.ico
+  features:
+    - navigation.tracking
   palette:
     - scheme: slate
       media: "(prefers-color-scheme: dark)"


### PR DESCRIPTION
This patch makes #733 more usable and it updates the address
of the current URL to the current anchor that you are reading at.

Like, mysite/mychapter#mysectiom, using which, sharing the links
will lead to the same place on the page that the user 1 was reading at.

Signed-off-by: black-dragon74 <niryadav@redhat.com>