### PR TITLE
Monitoring-Workload.md fix example command

### DIFF
--- a/docs/Administrator-Guide/Monitoring-Workload.md
+++ b/docs/Administrator-Guide/Monitoring-Workload.md
@@ -706,7 +706,7 @@ details:
   For example, to display additional information about the bricks of
   test-volume:
 
-      # gluster volume status test-volume details
+      # gluster volume status test-volume detail
       STATUS OF VOLUME: test-volume
       -------------------------------------------
       Brick                : arch:/export/1


### PR DESCRIPTION
`gluster volume status volume details` => detail

Otherwise you'd get a `No brick details in volume test-volume` error which is not very helpful