### PR TITLE
docs: fix reference to base-port and max-port

### DIFF
--- a/docs/Administrator-Guide/Setting-Up-Clients.md
+++ b/docs/Administrator-Guide/Setting-Up-Clients.md
@@ -55,12 +55,12 @@ To install Gluster Native Client on RPM distribution-based systems
     five bricks, you need to have ports 49152 to 49156 open.
 
     From Gluster-10 onwards, the brick ports will be randomized. A port is
-    randomly selected within the range of base_port to max_port as defined
-    in glusterd.vol file and then assigned to the brick. For example: if you have
+    randomly selected within the range of `base-port` to `max-port` as defined
+    in the glusterd.vol file and then assigned to the brick. For example: if you have
     five bricks, you need to have at least 5 ports open within the given range of
-    base_port and max_port.
+    `base-port` and `max-port`.
     To reduce the number of open ports (for best security practices), one can lower
-    the max_port value in the glusterd.vol file and restart glusterd to get it
+    the `max-port` value in the glusterd.vol file and restart glusterd to get it
     into effect.
 
     You can use the following chains with iptables:


### PR DESCRIPTION
Minor update to make the new `base-port` and `max-port` options easier to find. This was a breaking change for many people in GlusterFS 10.

The GlusterFS 10 release notes should also be updated to add a note about the new port ranges.