### PR TITLE
Do not use apt-key anymore as it is deprecated

### DIFF
--- a/docs/Install-Guide/Install.md
+++ b/docs/Install-Guide/Install.md
@@ -11,16 +11,16 @@ Packages are provided according to this [table](./Community-Packages.md).
 
 ###### For Debian
 
-Add the GPG key to apt:
+Download the GPG key to apt config directory:
 
 ```console
-wget -O - https://download.gluster.org/pub/gluster/glusterfs/9/rsa.pub | apt-key add -
+wget -O - https://download.gluster.org/pub/gluster/glusterfs/9/rsa.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/gluster.gpg
 ```
 
 If the rsa.pub is not available at the above location, please look here https://download.gluster.org/pub/gluster/glusterfs/7/rsa.pub and add the GPG key to apt:
 
 ```console
-wget -O - https://download.gluster.org/pub/gluster/glusterfs/7/rsa.pub | apt-key add -
+wget -O - https://download.gluster.org/pub/gluster/glusterfs/7/rsa.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/gluster.gpg
 ```
 
 Add the source:
@@ -29,7 +29,7 @@ Add the source:
 DEBID=$(grep 'VERSION_ID=' /etc/os-release | cut -d '=' -f 2 | tr -d '"')
 DEBVER=$(grep 'VERSION=' /etc/os-release | grep -Eo '[a-z]+')
 DEBARCH=$(dpkg --print-architecture)
-echo deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/${DEBARCH}/apt ${DEBVER} main > /etc/apt/sources.list.d/gluster.list
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/gluster.gpg] https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/${DEBID}/${DEBARCH}/apt ${DEBVER} main" > /etc/apt/sources.list.d/gluster.list
 ```
 
 Update package list:


### PR DESCRIPTION
Instead of using  `apt-key` to download/install the GlusterFS GPG key, we download it to */etc/apt/keyrings/* and explicitly use it in the *gluster.list* sources file.

This is the same approach as e.g. Docker is using.