### PR TITLE
Migrate to .readthedocs.yaml configuration file v2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,8 @@
-build:
-  image: latest
+version: 2
 
-python:
-  version: 3.6
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 requirements_file: requirements.txt


### PR DESCRIPTION
The build is failing with the following error:
Invalid configuration option "build.os": os not found"

Migrating the .readthedocs.yaml to configuration file v2 fixes the issue. Refer: https://blog.readthedocs.com/migrate-configuration-v2/