### PR TITLE
Fix typo in release note for version 11.0

### DIFF
--- a/docs/release-notes/11.0.md
+++ b/docs/release-notes/11.0.md
@@ -23,7 +23,7 @@ A full list of bugs that have been addressed is included further below.
 ## Highlights
 - Major performance impovement of ~36% with rmdir operations [#3685](https://github.com/gluster/glusterfs/issues/3685)
 -  Extension of ZFS support for snapshots [#2855](https://github.com/gluster/glusterfs/pull/2855)
-- Qouta implimentation based on namespace [#1750](https://github.com/gluster/glusterfs/pull/1750)
+- Quota implimentation based on namespace [#1750](https://github.com/gluster/glusterfs/pull/1750)
 - Major cleanups and readdir/readdirp improvements [link1](https://github.com/gluster/glusterfs/issues/3023#issuecomment-1011924449) [link2](https://github.com/gluster/glusterfs/issues/3023#issuecomment-1011924449)
 
 


### PR DESCRIPTION
Is Quota correct instead of Quota?